### PR TITLE
improve ADFS enveloped signature compatibility

### DIFF
--- a/lib/enveloped-signature.js
+++ b/lib/enveloped-signature.js
@@ -6,7 +6,7 @@ function EnvelopedSignature() {
 }
 
 EnvelopedSignature.prototype.process = function (node) {
-  var signature = xpath.SelectNodes(node.ownerDocument, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+  var signature = xpath.SelectNodes(node.ownerDocument, "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
   if (signature) signature.parentNode.removeChild(signature)
   return node.toString();
 };


### PR DESCRIPTION
I'm using xml-crypto and passport-saml with ADFS.

My ADFS produces SAML with enveloped signatures where the Signature node is three levels down, and the existing XPath in EnvelopedSignature.prototype.process is only looking for Signature nodes two levels down.
