### PR TITLE
support specifying reference node to insert signature after

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -329,7 +329,7 @@ SignedXml.prototype.addReference = function(xpath, transforms, digestAlgorithm, 
  * Compute the signature of the given xml (usign the already defined settings)
  *
  */
-SignedXml.prototype.computeSignature = function(xml) {  
+SignedXml.prototype.computeSignature = function(xml, xpathToNodeBeforeSignature) {  
   var doc = new Dom().parseFromString(xml)
   this.signatureXml = "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\">"                      
   
@@ -342,7 +342,19 @@ SignedXml.prototype.computeSignature = function(xml) {
   this.originalXmlWithIds = doc.toString()
 
   var signatureDoc = new Dom().parseFromString(this.signatureXml)
-  doc.documentElement.appendChild(signatureDoc.documentElement)
+  if (xpathToNodeBeforeSignature) {
+    var nodes = select(doc, xpathToNodeBeforeSignature);
+    if (!nodes && nodes.length === 0) {
+      doc.documentElement.appendChild(signatureDoc.documentElement);
+    } else {
+      var referenceNode = nodes[0];
+      // insert before referenceNode.nextSibling
+      doc.documentElement.insertBefore(signatureDoc.documentElement, referenceNode.nextSibling ? referenceNode.nextSibling : referenceNode);
+    }
+  } else {
+    doc.documentElement.appendChild(signatureDoc.documentElement)
+  }
+  
   this.signedXml = doc.toString()
 }
 


### PR DESCRIPTION
This is useful for SAML implementations that expect the signature to be placed after the Issuer, if not it fails validation. 

I added a new parameter and if it's not passed, it will behave as before.
