### PR TITLE
Don't premature end search for id attribute

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -436,7 +436,7 @@ SignedXml.prototype.ensureHasId = function(node) {
   else {
     for (var index in this.idAttributes) {
       attr = utils.findAttr(node, this.idAttributes[index], null);
-      break;
+      if (attr !== undefined) break;
     }
   }
 


### PR DESCRIPTION
When looking for the ID attribute, the existing code would only consider Id and not move on to look for ID.  This change corrects that.
