### PR TITLE
Oops. This change avoids exiting check for ID prematurely

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -436,7 +436,7 @@ SignedXml.prototype.ensureHasId = function(node) {
   else {
     for (var index in this.idAttributes) {
       attr = utils.findAttr(node, this.idAttributes[index], null);
-      if (attr !== undefined) break;
+      if (attr) break;
     }
   }
 


### PR DESCRIPTION
With my apologies, this change properly avoids prematurely exiting the id attribute lookup.  I guess I'm still figuring out this whole "git" thing as I thought I had pushed this change into my repo.  :)

Sorry about the last, incorrect pull request.
