### PR TITLE
Updating EnvelopedSignature transform

### DIFF
--- a/lib/enveloped-signature.js
+++ b/lib/enveloped-signature.js
@@ -5,11 +5,10 @@ exports.EnvelopedSignature = EnvelopedSignature;
 function EnvelopedSignature() {
 }
 
-EnvelopedSignature.prototype.process = function (node) {   
-  var signature = xpath(node.ownerDocument, "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];  
-  if (signature) signature.parentNode.removeChild(signature)
-  //return node.toString();
-  return node
+EnvelopedSignature.prototype.process = function (node) {
+  var signature = xpath(node, ".//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];  
+  if (signature) signature.parentNode.removeChild(signature);
+  return node;
 };
 
 EnvelopedSignature.prototype.getAlgorithmName = function () {

--- a/test/canonicalization-unit-tests.js
+++ b/test/canonicalization-unit-tests.js
@@ -328,5 +328,18 @@ module.exports = {
       test.equal("<p:y xmlns:p=\"myns\"></p:y>", res)
       test.done()
   }, 
- 
+
+  "Enveloped-signature canonicalization respects currentnode": function(test) {
+    // older versions of enveloped-signature removed the first signature in the whole doc, but should
+    //   be the signature inside the current node if we want to be able to verify multiple signatures
+    //   in a document.
+    var xml = '<x><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" /><y><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" /></y></x>';
+    var doc = new Dom().parseFromString(xml);
+    var node = select(doc, "//*[local-name(.)='y']")[0];
+    var sig = new SignedXml();
+    var transforms = ["http://www.w3.org/2000/09/xmldsig#enveloped-signature"];
+    var res = sig.getCanonXml(transforms, node);
+    test.equal("<y/>", res );
+    test.done();
+  },
 }


### PR DESCRIPTION
Updating EnvelopedSignature transform to strip signature from inside the current node, not just first signature in the document.

Includes a test to verify (and which fails before this change).

I ran into this problem in the passport-saml library, which needs to verify xml signatures on SAML documents.  Some SAML documents have two signatures on separate elements, and without this fix, when trying to verify the signature on the second element, it would strep the first enveloped signature from the whole document, but the element in question would still have its signature in place (and therefore get an incorrect digest).
