### PR TITLE
Safer iteration when Array.prototype has been extended

### DIFF
--- a/lib/exclusive-canonicalization.js
+++ b/lib/exclusive-canonicalization.js
@@ -42,6 +42,8 @@ ExclusiveCanonicalization.prototype.renderAttrs = function(node, defaultNS) {
   attrListToRender.sort(this.attrCompare);
 
   for (a in attrListToRender) {
+    if (!attrListToRender.hasOwnProperty(a)) continue;
+
     attr = attrListToRender[a];
     res.push(" ", attr.name, '="', utils.normalizeXmlIncludingCR(attr.value), '"');
   }
@@ -105,6 +107,8 @@ ExclusiveCanonicalization.prototype.renderNs = function(node, prefixesInScope, d
 
   //render namespaces
   for (a in nsListToRender) {
+    if (!nsListToRender.hasOwnProperty(a)) continue;
+
     p = nsListToRender[a];
     res.push(" xmlns:", p.prefix, '="', p.namespaceURI, '"');
   }

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -183,8 +183,8 @@ SignedXml.prototype.checkSignature = function(xml) {
   if (!this.validateReferences(doc)) {
     return false;
   }
-  
-  if (!this.validateSignatureValue()) {      
+
+  if (!this.validateSignatureValue()) {
     return false;
   }
 
@@ -223,7 +223,9 @@ SignedXml.prototype.findHashAlgorithm = function(name) {
 
 SignedXml.prototype.validateReferences = function(doc) {
   for (var r in this.references) {
-    var ref = this.references[r]    
+    if (!this.references.hasOwnProperty(r)) continue;
+
+    var ref = this.references[r]
     
     var uri = ref.uri[0]=="#" ? ref.uri.substring(1) : ref.uri
     var elem = [];
@@ -233,6 +235,8 @@ SignedXml.prototype.validateReferences = function(doc) {
     }
     else {
       for (var index in this.idAttributes) {
+        if (!this.idAttributes.hasOwnProperty(index)) continue;
+
         elem = select(doc, "//*[@*[local-name(.)='" + this.idAttributes[index] + "']='" + uri + "']")
         if (elem.length > 0) break;
       }
@@ -277,7 +281,9 @@ SignedXml.prototype.loadSignature = function(signatureXml) {
   if (references.length == 0) throw new Error("could not find any Reference elements")
 
   for (var i in references) {
-    this.loadReference(references[i])    
+    if (!references.hasOwnProperty(i)) continue;
+
+    this.loadReference(references[i])
   }
 
   this.signatureValue = 
@@ -314,6 +320,8 @@ SignedXml.prototype.loadReference = function(ref) {
     var transformsNode = nodes[0]
     var transformsAll = utils.findChilds(transformsNode, "Transform")  
     for (var t in transformsAll) {
+      if (!transformsAll.hasOwnProperty(t)) continue;
+
       var trans = transformsAll[t]
       transforms.push(utils.findAttr(trans, "Algorithm").value)
     }
@@ -394,6 +402,8 @@ SignedXml.prototype.createReferences = function(doc) {
 
   var res = ""
   for (var n in this.references) {
+    if (!this.references.hasOwnProperty(n)) continue;
+
     var ref = this.references[n]
       , nodes = select(doc, ref.xpath)
 
@@ -401,7 +411,9 @@ SignedXml.prototype.createReferences = function(doc) {
       throw new Error('the following xpath cannot be signed because it was not found: ' + ref.xpath)
     }
 
-    for (var h in nodes) {      
+    for (var h in nodes) {
+      if (!nodes.hasOwnProperty(h)) continue;
+
       var node = nodes[h]    
       if (ref.isEmptyUri) {
         res += "<Reference URI=\"\">"
@@ -413,6 +425,8 @@ SignedXml.prototype.createReferences = function(doc) {
       }
       res += "<Transforms>"
       for (var t in ref.transforms) {
+        if (!ref.transforms.hasOwnProperty(t)) continue;
+
         var trans = ref.transforms[t]
         var transform = this.findCanonicalizationAlgorithm(trans)
         res += "<Transform Algorithm=\"" + transform.getAlgorithmName() + "\" />"
@@ -434,6 +448,8 @@ SignedXml.prototype.createReferences = function(doc) {
 SignedXml.prototype.getCanonXml = function(transforms, node, options) {      
   var canonXml = node
   for (var t in transforms) {
+    if (!transforms.hasOwnProperty(t)) continue;
+
     var transform = this.findCanonicalizationAlgorithm(transforms[t])
     canonXml = transform.process(canonXml, options);
     //TODO: currently transform.process may return either Node or String value (enveloped transformation returns Node, exclusive-canonicalization returns String).
@@ -461,6 +477,8 @@ SignedXml.prototype.ensureHasId = function(node) {
   }
   else {
     for (var index in this.idAttributes) {
+      if (!this.idAttributes.hasOwnProperty(index)) continue;
+
       attr = utils.findAttr(node, this.idAttributes[index], null);
       if (attr) break;
     }


### PR DESCRIPTION
Adds handling to certain `for (x in a)` patterns for safer iteration when Array.prototype
has been extended with enumerable properties.
