### PR TITLE
Updated getKeyInfo function with actual implementation

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -870,7 +870,7 @@ SignedXml.prototype.getKeyInfo = function(prefix) {
 
   if (this.keyInfoProvider) {
     res += "<" + currentPrefix + "KeyInfo>"
-    res += this.keyInfoProvider.getKeyInfo(this.signingCert, prefix)
+    res += this.keyInfoProvider.getKeyInfo(this.signingCert || this.signingKey, prefix)
     res += "</" + currentPrefix + "KeyInfo>"
   }
   return res

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -18,12 +18,13 @@ function FileKeyInfo(file) {
   this.file = file
 
   this.getKeyInfo = function(key, prefix) {
-    let currentPrefix = prefix || ''
+    var currentPrefix = prefix || ''
     currentPrefix = currentPrefix ? currentPrefix + ':' : currentPrefix
-    let signingCert = '';
+    var signingCert = '';
     if (key) {
-      let certArray = Array.isArray(key) ? key : [key];
-      for(let cert in certArray) {
+      var certArray = [].concat(key);
+      for(var i = 0; i < certArray.length; ++i) {
+        var cert = certArray[i]
         signingCert += "<" + currentPrefix + "X509Certificate>" + cert + "</" + currentPrefix + "X509Certificate>"
       }
     }

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -18,9 +18,16 @@ function FileKeyInfo(file) {
   this.file = file
 
   this.getKeyInfo = function(key, prefix) {
-    prefix = prefix || ''
-    prefix = prefix ? prefix + ':' : prefix
-    return "<" + prefix + "X509Data></" + prefix + "X509Data>"
+    let currentPrefix = prefix || ''
+    currentPrefix = currentPrefix ? currentPrefix + ':' : currentPrefix
+    let signingCert = '';
+    if (key) {
+      let certArray = Array.isArray(key) ? key : [key];
+      for(let cert in certArray) {
+        signingCert += "<" + currentPrefix + "X509Certificate>" + cert + "</" + currentPrefix + "X509Certificate>"
+      }
+    }
+    return "<" + currentPrefix + "X509Data>" + signingCert + "</" + currentPrefix + "X509Data>"
   }
 
   this.getKey = function(keyInfo) {
@@ -298,6 +305,7 @@ function SignedXml(idMode, options) {
   this.references = []
   this.id = 0
   this.signingKey = null
+  this.signingCert = null
   this.signatureAlgorithm = this.options.signatureAlgorithm || "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
   this.keyInfoProvider = null
   this.canonicalizationAlgorithm = this.options.canonicalizationAlgorithm || "http://www.w3.org/2001/10/xml-exc-c14n#"
@@ -861,7 +869,7 @@ SignedXml.prototype.getKeyInfo = function(prefix) {
 
   if (this.keyInfoProvider) {
     res += "<" + currentPrefix + "KeyInfo>"
-    res += this.keyInfoProvider.getKeyInfo(this.signingKey, prefix)
+    res += this.keyInfoProvider.getKeyInfo(this.signingCert, prefix)
     res += "</" + currentPrefix + "KeyInfo>"
   }
   return res


### PR DESCRIPTION
Hello @cjbarth, @LoneRifle, @yaronn,
I have added implementation for getKeyInfo function, please check if it looks good, then I'll proceed with unit tests.   

I am getting confused with below line of codes,

For FileKeyInfo, I'm assuming it accepts file which will be public X509 certificate and this.getKeyInfo function will return the X509Data. **But, what is the use of this.getKey()??** I'm assuming it will return public certificate. But, in some places it used as privateKey, as shown in below statements,

In node-saml->src->xml.ts->signXml, signingKey gets the privateKey value assigned, as shown below,
![image](https://user-images.githubusercontent.com/6399781/179564006-4a567163-1350-4476-9a9e-eb8486915fd2.png)

However, in xml-crypto->lib->signed-sml.js, signingKey gets the value from KeyInfoProvider.getKey(this.keyInfo) which looks to be public certificate..
![image](https://user-images.githubusercontent.com/6399781/179565829-f71e9a56-23d3-40bc-b3e8-ab68947103c1.png)


Can you please help me to clear this..