### PR TITLE
make FileKeyInfo extensible for compatibility with TypeScript

### DIFF
--- a/lib/file-key-info.js
+++ b/lib/file-key-info.js
@@ -1,0 +1,17 @@
+var StringKeyInfo = require("./string-key-info")
+  , fs = require("fs")
+
+/**
+ * A key info provider implementation
+ * 
+ * @param {string} file path to public certificate 
+ */
+function FileKeyInfo(file) {
+  var key = fs.readFileSync(file)
+  StringKeyInfo.apply(this, [key])
+}
+
+FileKeyInfo.prototype = StringKeyInfo.prototype
+FileKeyInfo.prototype.constructor = FileKeyInfo
+
+module.exports = FileKeyInfo

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -4,51 +4,13 @@ var xpath = require('xpath')
   , c14n = require('./c14n-canonicalization')
   , execC14n = require('./exclusive-canonicalization')
   , EnvelopedSignature = require('./enveloped-signature').EnvelopedSignature
+  , StringKeyInfo = require('./string-key-info')
+  , FileKeyInfo = require('./file-key-info')
   , crypto = require('crypto')
-  , fs = require('fs')
 
 exports.SignedXml = SignedXml
+exports.StringKeyInfo = StringKeyInfo
 exports.FileKeyInfo = FileKeyInfo
-
-/**
- * A key info provider implementation
- *
- */
-function FileKeyInfo(file) {
-  this.file = file
-}
-
-
-/**
- * Builds the contents of a KeyInfo element as an XML string.
- *
- * Currently, this returns exactly one empty X509Data element
- * (e.g. "<X509Data></X509Data>"). The resultant X509Data element will be
- * prefaced with a namespace alias if a value for the prefix argument
- * is provided. In example, if the value of the prefix argument is 'foo', then
- * the resultant XML string will be "<foo:X509Element></foo:X509Element>"
- *
- * @param key (not used) the signing/private key as a string
- * @param prefix an optional namespace alias to be used for the generated XML
- * @return an XML string representation of the contents of a KeyInfo element
- */
-FileKeyInfo.prototype.getKeyInfo = function(key, prefix) {
-  prefix = prefix || ''
-  prefix = prefix ? prefix + ':' : prefix
-  return "<" + prefix + "X509Data></" + prefix + "X509Data>"
-}
-
-/**
- * Returns the value of the signing certificate based on the contents of the
- * specified KeyInfo.
- *
- * @param keyInfo (not used) an array with exactly one KeyInfo element
- * @return the signing certificate as a string
- */
-FileKeyInfo.prototype.getKey = function(keyInfo) {
-  return fs.readFileSync(this.file)
-}
-
 
 /**
  * Hash algorithm implementation

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -16,17 +16,39 @@ exports.FileKeyInfo = FileKeyInfo
  */
 function FileKeyInfo(file) {
   this.file = file
-
-  this.getKeyInfo = function(key, prefix) {
-    prefix = prefix || ''
-    prefix = prefix ? prefix + ':' : prefix
-    return "<" + prefix + "X509Data></" + prefix + "X509Data>"
-  }
-
-  this.getKey = function(keyInfo) {
-    return fs.readFileSync(this.file)
-  }
 }
+
+
+/**
+ * Builds the contents of a KeyInfo element as an XML string.
+ *
+ * Currently, this returns exactly one empty X509Data element
+ * (e.g. "<X509Data></X509Data>"). The resultant X509Data element will be
+ * prefaced with a namespace alias if a value for the prefix argument
+ * is provided. In example, if the value of the prefix argument is 'foo', then
+ * the resultant XML string will be "<foo:X509Element></foo:X509Element>"
+ *
+ * @param key (not used) the signing/private key as a string
+ * @param prefix an optional namespace alias to be used for the generated XML
+ * @return an XML string representation of the contents of a KeyInfo element
+ */
+FileKeyInfo.prototype.getKeyInfo = function(key, prefix) {
+  prefix = prefix || ''
+  prefix = prefix ? prefix + ':' : prefix
+  return "<" + prefix + "X509Data></" + prefix + "X509Data>"
+}
+
+/**
+ * Returns the value of the signing certificate based on the contents of the
+ * specified KeyInfo.
+ *
+ * @param keyInfo (not used) an array with exactly one KeyInfo element
+ * @return the signing certificate as a string
+ */
+FileKeyInfo.prototype.getKey = function(keyInfo) {
+  return fs.readFileSync(this.file)
+}
+
 
 /**
  * Hash algorithm implementation

--- a/lib/string-key-info.js
+++ b/lib/string-key-info.js
@@ -1,0 +1,40 @@
+/**
+ * A basic string based implementation of a FileInfoProvider
+ *  
+ * @param {string} key the string contents of a public certificate
+ */
+function StringKeyInfo(key) {
+  this.key = key;
+}
+
+/**
+ * Builds the contents of a KeyInfo element as an XML string.
+ *
+ * Currently, this returns exactly one empty X509Data element
+ * (e.g. "<X509Data></X509Data>"). The resultant X509Data element will be
+ * prefaced with a namespace alias if a value for the prefix argument
+ * is provided. In example, if the value of the prefix argument is 'foo', then
+ * the resultant XML string will be "<foo:X509Element></foo:X509Element>"
+ *
+ * @param key (not used) the signing/private key as a string
+ * @param prefix an optional namespace alias to be used for the generated XML
+ * @return an XML string representation of the contents of a KeyInfo element
+ */
+StringKeyInfo.prototype.getKeyInfo = function (key, prefix) {
+  prefix = prefix || "";
+  prefix = prefix ? prefix + ":" : prefix;
+  return "<" + prefix + "X509Data></" + prefix + "X509Data>";
+};
+
+/**
+ * Returns the value of the signing certificate based on the contents of the
+ * specified KeyInfo.
+ *
+ * @param keyInfo (not used) an array with exactly one KeyInfo element
+ * @return the signing certificate as a string
+ */
+StringKeyInfo.prototype.getKey = function (keyInfo) {
+  return this.key;
+};
+
+module.exports = StringKeyInfo;

--- a/lib/string-key-info.js
+++ b/lib/string-key-info.js
@@ -14,7 +14,7 @@ function StringKeyInfo(key) {
  * (e.g. "<X509Data></X509Data>"). The resultant X509Data element will be
  * prefaced with a namespace alias if a value for the prefix argument
  * is provided. In example, if the value of the prefix argument is 'foo', then
- * the resultant XML string will be "<foo:X509Element></foo:X509Element>"
+ * the resultant XML string will be "<foo:X509Data></foo:X509Data>"
  *
  * @param key (not used) the signing/private key as a string
  * @param prefix an optional namespace alias to be used for the generated XML

--- a/test/document-test.js
+++ b/test/document-test.js
@@ -3,12 +3,25 @@ var xpath = require('xpath');
 var xmldom = require('@xmldom/xmldom');
 var fs = require('fs');
 
-exports['test with a document '] = function (test) {
+exports['test with a document (using FileKeyInfo)'] = function (test) {
   var xml = fs.readFileSync('./test/static/valid_saml.xml', 'utf-8');
   var doc = new xmldom.DOMParser().parseFromString(xml);
   var signature = new xmldom.DOMParser().parseFromString(xpath.select("/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']", doc)[0].toString());
   var sig = new crypto.SignedXml();
   sig.keyInfoProvider = new crypto.FileKeyInfo("./test/static/feide_public.pem");
+  sig.loadSignature(signature);
+  var result = sig.checkSignature(xml);
+  test.equal(result, true);
+  test.done();
+};
+
+exports['test with a document (using StringKeyInfo)'] = function (test) {
+  var xml = fs.readFileSync('./test/static/valid_saml.xml', 'utf-8');
+  var doc = new xmldom.DOMParser().parseFromString(xml);
+  var signature = new xmldom.DOMParser().parseFromString(xpath.select("/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']", doc)[0].toString());
+  var sig = new crypto.SignedXml();
+  var feidePublicCert = fs.readFileSync('./test/static/feide_public.pem');
+  sig.keyInfoProvider = new crypto.StringKeyInfo(feidePublicCert);
   sig.loadSignature(signature);
   var result = sig.checkSignature(xml);
   test.equal(result, true);


### PR DESCRIPTION
The type definitions for this awesome library require that the value of `SignedXML.keyInfoProvider` be an instance of `FileKeyInfo`, but the methods on FileKeyInfo belong to the instance itself and not the prototype. This issue is only strictly a problem for TypeScript, but this change has a beneficial affect (in terms of reuse) on NodeJS clients, as well, and this is a non-breaking change. 

Also adding some documentation to the methods to clear up some of the confusion. Feedback is welcome!

Closes #272