### PR TITLE
Add support for appending attributes to KeyInfo element

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,6 +79,7 @@ export class SignedXml {
 export interface KeyInfo {
     getKey(keyInfo?: Node[] | null): Buffer;
     getKeyInfo(key?: string, prefix?: string): string;
+    attrs?: {[key: string]: any} | undefined;
 }
 
 export class FileKeyInfo implements KeyInfo {

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -845,7 +845,13 @@ SignedXml.prototype.getKeyInfo = function(prefix) {
   currentPrefix = currentPrefix ? currentPrefix + ':' : currentPrefix
 
   if (this.keyInfoProvider) {
-    res += "<" + currentPrefix + "KeyInfo>"
+    var keyInfoAttrs = ""
+    if (this.keyInfoProvider.attrs) {
+      Object.keys(this.keyInfoProvider.attrs).forEach((name) => {
+        keyInfoAttrs += " " + name + "=\"" + this.keyInfoProvider.attrs[name] + "\""
+      })
+    }
+    res += "<" + currentPrefix + "KeyInfo" + keyInfoAttrs + ">"
     res += this.keyInfoProvider.getKeyInfo(this.signingCert || this.signingKey, prefix)
     res += "</" + currentPrefix + "KeyInfo>"
   }


### PR DESCRIPTION
Added a new optional property, attrs, to the KeyInfo class.
The attrs property is an object that holds key-value pairs representing the attributes and their corresponding values. 
When present, these attributes will be appended to the KeyInfo element during XML generation.

Example:

```
sig.keyInfoProvider = {
    getKeyInfo: () => {
        return `<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="STR-${securityTokenReferenceGuid}">`
            + `<wsse:Reference URI="#X509-${randomUUID()}" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>`
            + `</wsse:SecurityTokenReference>`
    },
    getKey: () => Buffer.from(privateKey),
    attrs: {
        Id: `KI-${randomUUID()}`,
    }
};
```

Result:

```
<ds:KeyInfo Id="KI-a8bb2a1a-32dd-449e-9bf0-187dd8ea4ee6">
  <wsse:SecurityTokenReference wsu:Id="STR-0096ce19-3fbf-414f-94e9-f7a0d601b3f4">
    <wsse:Reference URI="#X509-8cc9b13b-ee21-426e-b8d1-75cddddbe6e5"
      ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>
  </wsse:SecurityTokenReference>
</ds:KeyInfo>
```