### PR TITLE
Use inclusiveNamespacesPrefixList to generate InclusiveNamespaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ export class SignedXml {
     static HashAlgorithms: {[uri: string]: new () => HashAlgorithm};
     static SignatureAlgorithms: {[uri: string]: new () => SignatureAlgorithm};
     canonicalizationAlgorithm: string;
+    inclusiveNamespacesPrefixList: string;
     keyInfoProvider: KeyInfo;
     references: Reference[];
     signatureAlgorithm: string;
@@ -44,6 +45,7 @@ export class SignedXml {
     validationErrors: string[];
     constructor(idMode?: string | null, options?: {
         canonicalizationAlgorithm?: string | undefined
+        inclusiveNamespacesPrefixList?: string | undefined
         idAttribute?: string | undefined
         implicitTransforms?: ReadonlyArray<string> | undefined
         signatureAlgorithm?: string | undefined

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -286,6 +286,7 @@ function SignedXml(idMode, options) {
   this.signatureAlgorithm = this.options.signatureAlgorithm || "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
   this.keyInfoProvider = null
   this.canonicalizationAlgorithm = this.options.canonicalizationAlgorithm || "http://www.w3.org/2001/10/xml-exc-c14n#"
+  this.inclusiveNamespacesPrefixList = this.options.inclusiveNamespacesPrefixList || ""
   this.signedXml = ""
   this.signatureXml = ""
   this.signatureNode = null
@@ -991,8 +992,15 @@ SignedXml.prototype.createSignedInfo = function(doc, prefix) {
   currentPrefix = currentPrefix ? currentPrefix + ':' : currentPrefix
 
   var res = "<" + currentPrefix + "SignedInfo>"
-  res += "<" + currentPrefix + "CanonicalizationMethod Algorithm=\"" + transform.getAlgorithmName() + "\" />" +
-          "<" + currentPrefix + "SignatureMethod Algorithm=\"" + algo.getAlgorithmName() + "\" />"
+  res += "<" + currentPrefix + "CanonicalizationMethod Algorithm=\"" + transform.getAlgorithmName() + "\""
+  if (this.inclusiveNamespacesPrefixList.length > 0) {
+    res += ">"
+    res += "<InclusiveNamespaces PrefixList=\"" + this.inclusiveNamespacesPrefixList + "\" xmlns=\""+transform.getAlgorithmName()+"\"/>"
+    res += "</" + currentPrefix + "CanonicalizationMethod>"
+  } else {
+    res += " />"
+  }
+  res += "<" + currentPrefix + "SignatureMethod Algorithm=\"" + algo.getAlgorithmName() + "\" />"
 
   res += this.createReferences(doc, prefix)
   res += "</" + currentPrefix + "SignedInfo>"

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -893,7 +893,7 @@ SignedXml.prototype.createReferences = function(doc, prefix) {
         var trans = ref.transforms[t]
         var transform = this.findCanonicalizationAlgorithm(trans)
         res += "<" + prefix + "Transform Algorithm=\"" + transform.getAlgorithmName() + "\""
-        if (ref.inclusiveNamespacesPrefixList.length > 0) {
+        if (ref.inclusiveNamespacesPrefixList && ref.inclusiveNamespacesPrefixList.length > 0) {
           res += ">"
           res += "<InclusiveNamespaces PrefixList=\"" + ref.inclusiveNamespacesPrefixList + "\" xmlns=\""+transform.getAlgorithmName()+"\"/>"
           res += "</" + prefix + "Transform>"

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -200,11 +200,11 @@ function HMACSHA1() {
  */
 function findAncestorNs(doc, docSubsetXpath, namespaceResolver){
   var docSubset = xpath.selectWithResolver(docSubsetXpath, doc, namespaceResolver);
-
+  
   if(!Array.isArray(docSubset) || docSubset.length < 1){
     return [];
   }
-
+  
   // Remove duplicate on ancestor namespace
   var ancestorNs = collectAncestorNamespaces(docSubset[0]);
   var ancestorNsWithoutDuplicate = [];
@@ -216,12 +216,12 @@ function findAncestorNs(doc, docSubsetXpath, namespaceResolver){
         break;
       }
     }
-
+    
     if(notOnTheList){
       ancestorNsWithoutDuplicate.push(ancestorNs[i]);
     }
   }
-
+  
   // Remove namespaces which are already declared in the subset with the same prefix
   var returningNs = [];
   var subsetAttributes = docSubset[0].attributes;
@@ -236,12 +236,12 @@ function findAncestorNs(doc, docSubsetXpath, namespaceResolver){
         break;
       }
     }
-
+  
     if(isUnique){
       returningNs.push(ancestorNsWithoutDuplicate[j]);
     }
   }
-
+  
   return returningNs;
 }
 
@@ -251,13 +251,13 @@ function collectAncestorNamespaces(node, nsArray){
   if(!nsArray){
     nsArray = [];
   }
-
+  
   var parent = node.parentNode;
-
+  
   if(!parent){
     return nsArray;
   }
-
+  
   if(parent.attributes && parent.attributes.length > 0){
     for(var i=0;i<parent.attributes.length;i++){
       var attr = parent.attributes[i];
@@ -266,7 +266,7 @@ function collectAncestorNamespaces(node, nsArray){
       }
     }
   }
-
+  
   return collectAncestorNamespaces(parent, nsArray);
 }
 
@@ -401,7 +401,7 @@ SignedXml.prototype.checkSignature = function(xml, callback) {
 SignedXml.prototype.getCanonSignedInfoXml = function(doc) {
   var signedInfo = utils.findChilds(this.signatureNode, "SignedInfo")
   if (signedInfo.length==0) throw new Error("could not find SignedInfo element in the message")
-
+  
   if(this.canonicalizationAlgorithm === "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
   || this.canonicalizationAlgorithm === "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments")
   {
@@ -411,13 +411,13 @@ SignedXml.prototype.getCanonSignedInfoXml = function(doc) {
       );
     }
   }
-
+  
   /**
    * Search for ancestor namespaces before canonicalization.
    */
   var ancestorNamespaces = [];
   ancestorNamespaces = findAncestorNs(doc, "//*[local-name()='SignedInfo']");
-
+  
   var c14nOptions = {
     ancestorNamespaces: ancestorNamespaces
   };
@@ -428,7 +428,7 @@ SignedXml.prototype.getCanonReferenceXml = function(doc, ref, node) {
   /**
    * Search for ancestor namespaces before canonicalization.
    */
-  if(Array.isArray(ref.transforms)){
+  if(Array.isArray(ref.transforms)){  
     ref.ancestorNamespaces = findAncestorNs(doc, ref.xpath, this.namespaceResolver)
   }
 
@@ -517,7 +517,7 @@ SignedXml.prototype.validateReferences = function(doc) {
                         ref.uri + " but could not find such element in the xml")
       return false
     }
-
+  
     var canonXml = this.getCanonReferenceXml(doc, ref, elem[0])
 
     var hash = this.findHashAlgorithm(ref.digestAlgorithm)
@@ -651,7 +651,7 @@ SignedXml.prototype.loadReference = function(ref) {
       transforms.push(t);
     });
   }
-
+  
 /**
  * DigestMethods take an octet stream rather than a node set. If the output of the last transform is a node set, we
  * need to canonicalize the node set to an octet stream using non-exclusive canonicalization. If there are no
@@ -721,7 +721,7 @@ SignedXml.prototype.computeSignature = function(xml, opts, callback) {
   var existingPrefixes = opts.existingPrefixes || {};
 
   this.namespaceResolver = {
-    lookupNamespaceURI: function(prefix) {
+    lookupNamespaceURI: function(prefix) {       
       return existingPrefixes[prefix];
     }
   }

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -200,11 +200,11 @@ function HMACSHA1() {
  */
 function findAncestorNs(doc, docSubsetXpath, namespaceResolver){
   var docSubset = xpath.selectWithResolver(docSubsetXpath, doc, namespaceResolver);
-  
+
   if(!Array.isArray(docSubset) || docSubset.length < 1){
     return [];
   }
-  
+
   // Remove duplicate on ancestor namespace
   var ancestorNs = collectAncestorNamespaces(docSubset[0]);
   var ancestorNsWithoutDuplicate = [];
@@ -216,12 +216,12 @@ function findAncestorNs(doc, docSubsetXpath, namespaceResolver){
         break;
       }
     }
-    
+
     if(notOnTheList){
       ancestorNsWithoutDuplicate.push(ancestorNs[i]);
     }
   }
-  
+
   // Remove namespaces which are already declared in the subset with the same prefix
   var returningNs = [];
   var subsetAttributes = docSubset[0].attributes;
@@ -236,12 +236,12 @@ function findAncestorNs(doc, docSubsetXpath, namespaceResolver){
         break;
       }
     }
-  
+
     if(isUnique){
       returningNs.push(ancestorNsWithoutDuplicate[j]);
     }
   }
-  
+
   return returningNs;
 }
 
@@ -251,13 +251,13 @@ function collectAncestorNamespaces(node, nsArray){
   if(!nsArray){
     nsArray = [];
   }
-  
+
   var parent = node.parentNode;
-  
+
   if(!parent){
     return nsArray;
   }
-  
+
   if(parent.attributes && parent.attributes.length > 0){
     for(var i=0;i<parent.attributes.length;i++){
       var attr = parent.attributes[i];
@@ -266,7 +266,7 @@ function collectAncestorNamespaces(node, nsArray){
       }
     }
   }
-  
+
   return collectAncestorNamespaces(parent, nsArray);
 }
 
@@ -401,7 +401,7 @@ SignedXml.prototype.checkSignature = function(xml, callback) {
 SignedXml.prototype.getCanonSignedInfoXml = function(doc) {
   var signedInfo = utils.findChilds(this.signatureNode, "SignedInfo")
   if (signedInfo.length==0) throw new Error("could not find SignedInfo element in the message")
-  
+
   if(this.canonicalizationAlgorithm === "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
   || this.canonicalizationAlgorithm === "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments")
   {
@@ -411,13 +411,13 @@ SignedXml.prototype.getCanonSignedInfoXml = function(doc) {
       );
     }
   }
-  
+
   /**
    * Search for ancestor namespaces before canonicalization.
    */
   var ancestorNamespaces = [];
   ancestorNamespaces = findAncestorNs(doc, "//*[local-name()='SignedInfo']");
-  
+
   var c14nOptions = {
     ancestorNamespaces: ancestorNamespaces
   };
@@ -428,7 +428,7 @@ SignedXml.prototype.getCanonReferenceXml = function(doc, ref, node) {
   /**
    * Search for ancestor namespaces before canonicalization.
    */
-  if(Array.isArray(ref.transforms)){  
+  if(Array.isArray(ref.transforms)){
     ref.ancestorNamespaces = findAncestorNs(doc, ref.xpath, this.namespaceResolver)
   }
 
@@ -517,7 +517,7 @@ SignedXml.prototype.validateReferences = function(doc) {
                         ref.uri + " but could not find such element in the xml")
       return false
     }
-  
+
     var canonXml = this.getCanonReferenceXml(doc, ref, elem[0])
 
     var hash = this.findHashAlgorithm(ref.digestAlgorithm)
@@ -651,7 +651,7 @@ SignedXml.prototype.loadReference = function(ref) {
       transforms.push(t);
     });
   }
-  
+
 /**
  * DigestMethods take an octet stream rather than a node set. If the output of the last transform is a node set, we
  * need to canonicalize the node set to an octet stream using non-exclusive canonicalization. If there are no
@@ -721,7 +721,7 @@ SignedXml.prototype.computeSignature = function(xml, opts, callback) {
   var existingPrefixes = opts.existingPrefixes || {};
 
   this.namespaceResolver = {
-    lookupNamespaceURI: function(prefix) {       
+    lookupNamespaceURI: function(prefix) {
       return existingPrefixes[prefix];
     }
   }
@@ -893,7 +893,7 @@ SignedXml.prototype.createReferences = function(doc, prefix) {
         var trans = ref.transforms[t]
         var transform = this.findCanonicalizationAlgorithm(trans)
         res += "<" + prefix + "Transform Algorithm=\"" + transform.getAlgorithmName() + "\""
-        if (ref.inclusiveNamespacesPrefixList && ref.inclusiveNamespacesPrefixList.length > 0) {
+        if (ref.inclusiveNamespacesPrefixList) {
           res += ">"
           res += "<InclusiveNamespaces PrefixList=\"" + ref.inclusiveNamespacesPrefixList + "\" xmlns=\""+transform.getAlgorithmName()+"\"/>"
           res += "</" + prefix + "Transform>"
@@ -993,7 +993,7 @@ SignedXml.prototype.createSignedInfo = function(doc, prefix) {
 
   var res = "<" + currentPrefix + "SignedInfo>"
   res += "<" + currentPrefix + "CanonicalizationMethod Algorithm=\"" + transform.getAlgorithmName() + "\""
-  if (this.inclusiveNamespacesPrefixList.length > 0) {
+  if (this.inclusiveNamespacesPrefixList) {
     res += ">"
     res += "<InclusiveNamespaces PrefixList=\"" + this.inclusiveNamespacesPrefixList + "\" xmlns=\""+transform.getAlgorithmName()+"\"/>"
     res += "</" + currentPrefix + "CanonicalizationMethod>"

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -891,7 +891,14 @@ SignedXml.prototype.createReferences = function(doc, prefix) {
 
         var trans = ref.transforms[t]
         var transform = this.findCanonicalizationAlgorithm(trans)
-        res += "<" + prefix + "Transform Algorithm=\"" + transform.getAlgorithmName() + "\" />"
+        res += "<" + prefix + "Transform Algorithm=\"" + transform.getAlgorithmName() + "\""
+        if (ref.inclusiveNamespacesPrefixList.length > 0) {
+          res += ">"
+          res += "<InclusiveNamespaces PrefixList=\"" + ref.inclusiveNamespacesPrefixList + "\" xmlns=\""+transform.getAlgorithmName()+"\"/>"
+          res += "</" + prefix + "Transform>"
+        } else {
+          res += " />"
+        }
       }
 
       var canonXml = this.getCanonReferenceXml(doc, ref, node)

--- a/test/signature-unit-tests.js
+++ b/test/signature-unit-tests.js
@@ -790,7 +790,7 @@ function verifySignature(xml, mode) {
 
   var doc = new dom().parseFromString(xml)
   var node = select("//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']", doc)[0]
-
+  
   var sig = new SignedXml(mode)
   sig.keyInfoProvider = new FileKeyInfo("./test/static/client_public.pem")
   sig.loadSignature(node)


### PR DESCRIPTION
Currently, the `inclusiveNamespacesPrefixList` property on the Reference interface is only used during loading of references.
This change would allow the use of the same property during the creation of references to add a `InclusiveNamespaces` element.

Example:

```
sig.addReference(
    "//*[local-name(.)='Timestamp']",
    ["http://www.w3.org/2001/10/xml-exc-c14n#"],
    'http://www.w3.org/2000/09/xmldsig#sha1',
    '','',
    'wsse soapenc soapenv xsd xsi');
```

Result:

```
<ds:Reference URI="#TS-b3f4bfa7-fe3b-4ee1-aa8c-289ee7de442b">
  <ds:Transforms>
    <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
       <InclusiveNamespaces PrefixList="wsse soapenc soapenv xsd xsi"
          xmlns="http://www.w3.org/2001/10/xml-exc-c14n#"/>
     </ds:Transform>
   </ds:Transforms>
   <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
   <ds:DigestValue>DGrj1zr8K0OsBojzMSMVowotX60=</ds:DigestValue>
</ds:Reference>
```
    
Added `inclusiveNamespacesPrefixList` property to SignedXML options, which if present generates InclusiveNamespaces element inside CanonicalizationMethod.

Example:

```
const sig = new SignedXml(null, {idAttribute: 'Id', inclusiveNamespacesPrefixList: 'soapenc soapenv xsd xsi'});
```

Result:

```
<ds:Signature Id="SIG-0271048c-6ea7-4e9d-85e2-1819c3ce3848" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
  <ds:SignedInfo>
    <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
      <InclusiveNamespaces PrefixList="soapenc soapenv xsd xsi"
        xmlns="http://www.w3.org/2001/10/xml-exc-c14n#"/>
      </ds:CanonicalizationMethod>
```
