### PR TITLE
Add support for appending attributes to KeyInfo element

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,6 +79,7 @@ export class SignedXml {
 export interface KeyInfo {
     getKey(keyInfo?: Node[] | null): Buffer;
     getKeyInfo(key?: string, prefix?: string): string;
+    attrs?: {[key: string]: any} | undefined;
 }
 
 export class FileKeyInfo implements KeyInfo {

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -845,7 +845,13 @@ SignedXml.prototype.getKeyInfo = function(prefix) {
   currentPrefix = currentPrefix ? currentPrefix + ':' : currentPrefix
 
   if (this.keyInfoProvider) {
-    res += "<" + currentPrefix + "KeyInfo>"
+    var keyInfoAttrs = ""
+    if (this.keyInfoProvider.attrs) {
+      Object.keys(this.keyInfoProvider.attrs).forEach((name) => {
+        keyInfoAttrs += " " + name + "=\"" + this.keyInfoProvider.attrs[name] + "\""
+      })
+    }
+    res += "<" + currentPrefix + "KeyInfo" + keyInfoAttrs + ">"
     res += this.keyInfoProvider.getKeyInfo(this.signingCert || this.signingKey, prefix)
     res += "</" + currentPrefix + "KeyInfo>"
   }

--- a/test/signature-unit-tests.js
+++ b/test/signature-unit-tests.js
@@ -734,6 +734,36 @@ module.exports = {
     test.done();
   },
 
+  "adds attributes to KeyInfo element when attrs are present in keyInfoProvider": function (test) {
+    var xml = "<root><x /></root>";
+    var sig = new SignedXml();
+    sig.signingKey = fs.readFileSync("./test/static/client.pem");
+    sig.keyInfoProvider = {
+      attrs: {
+        CustomUri: "http://www.example.com/keyinfo",
+        CustomAttribute: "custom-value"
+      },
+        getKeyInfo: function () {
+          return "<dummy/>";
+        }
+    };
+
+    sig.computeSignature(xml);
+    var signedXml = sig.getSignedXml();
+
+    var doc = new dom().parseFromString(signedXml);
+    var keyInfoElement = select("//*[local-name(.)='KeyInfo']", doc.documentElement);
+    test.equal(keyInfoElement.length, 1, "KeyInfo element should exist");
+
+    var algorithmAttribute = keyInfoElement[0].getAttribute('CustomUri');
+    test.equal(algorithmAttribute, 'http://www.example.com/keyinfo', "KeyInfo element should have the correct CustomUri attribute value");
+
+    var customAttribute = keyInfoElement[0].getAttribute('CustomAttribute');
+    test.equal(customAttribute, 'custom-value', "KeyInfo element should have the correct CustomAttribute attribute value");
+
+    test.done();
+  },
+
 }
 
 function passValidSignature(test, file, mode) {


### PR DESCRIPTION
Added a new optional property, attrs, to the KeyInfo interface.
The attrs property is an object that holds key-value pairs representing the attributes and their corresponding values. 
When present, these attributes will be appended to the KeyInfo element during XML generation.

Example:

```
sig.keyInfoProvider = {
    getKeyInfo: () => {
        return `<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="STR-${securityTokenReferenceGuid}">`
            + `<wsse:Reference URI="#X509-${randomUUID()}" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>`
            + `</wsse:SecurityTokenReference>`
    },
    getKey: () => Buffer.from(privateKey),
    attrs: {
        Id: `KI-${randomUUID()}`,
    }
};
```

Result:

```
<ds:KeyInfo Id="KI-a8bb2a1a-32dd-449e-9bf0-187dd8ea4ee6">
  <wsse:SecurityTokenReference wsu:Id="STR-0096ce19-3fbf-414f-94e9-f7a0d601b3f4">
    <wsse:Reference URI="#X509-8cc9b13b-ee21-426e-b8d1-75cddddbe6e5"
      ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>
  </wsse:SecurityTokenReference>
</ds:KeyInfo>
```