### PR TITLE
Make linting rules more strict

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,13 @@
   "rules": {
     "no-console": "error",
     "no-unused-vars": "warn",
-    "no-prototype-builtins": "warn"
+    "no-prototype-builtins": "warn",
+    "one-var": ["warn", "never"],
+    "no-duplicate-imports": "error",
+    "no-use-before-define": "error",
+    "curly": "warn",
+    "eqeqeq": ["error", "smart"],
+    "no-var": "warn",
+    "prefer-const":"warn"
   }
 }


### PR DESCRIPTION
This PR aims to improve code quality and consistency by tightening up some linting rules slightly. These rules require Node >=4 because of the rule to prefer `let` over `var`.