### PR TITLE
Adjust references for `node-saml` organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xml-crypto
 
-![Build](https://github.com/yaronn/xml-crypto/actions/workflows/ci.yml/badge.svg)
+![Build](https://github.com/node-saml/xml-crypto/actions/workflows/ci.yml/badge.svg)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 An xml digital signature library for node. Xml encryption is coming soon. Written in pure javascript!

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@node-saml/xml-crypto",
+  "name": "xml-crypto",
   "version": "3.0.1",
   "private": false,
   "description": "Xml digital signature and encryption library for Node.js",


### PR DESCRIPTION
The README badge was pointing to the wrong location and the NPM package name was scoped, which it doesn't seem like we're using yet. We should discuss if we want to move this NPM package to be a scopped one and deprecate the unscopped version. For now, we have to unscope it so that we can do a release.