### PR TITLE
Use correct path for code coverage reports

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -2,5 +2,5 @@
   "all": true,
   "check-coverage": false,
   "reporter": ["lcov", "text"],
-  "include": ["src/**"]
+  "include": ["lib/**"]
 }


### PR DESCRIPTION
The wrong path was used for the configuration of `nyc`, so a blank report was being generated.