### PR TITLE
Enforce eslint `no-unused-vars`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
   "extends": ["eslint:recommended", "prettier"],
   "rules": {
     "no-console": "error",
-    "no-unused-vars": "warn",
+    "no-unused-vars": "error",
     "no-prototype-builtins": "error",
     "one-var": ["error", "never"],
     "no-duplicate-imports": "error",

--- a/lib/c14n-canonicalization.js
+++ b/lib/c14n-canonicalization.js
@@ -37,7 +37,7 @@ class C14nCanonicalization {
     return attr1.localeCompare(attr2);
   }
 
-  renderAttrs(node, defaultNS) {
+  renderAttrs(node) {
     let i;
     let attr;
     const attrListToRender = [];
@@ -171,7 +171,7 @@ class C14nCanonicalization {
       defaultNsForPrefix,
       ancestorNamespaces
     );
-    const res = ["<", node.tagName, ns.rendered, this.renderAttrs(node, ns.newDefaultNs), ">"];
+    const res = ["<", node.tagName, ns.rendered, this.renderAttrs(node), ">"];
 
     for (i = 0; i < node.childNodes.length; ++i) {
       pfxCopy = prefixesInScope.slice(0);

--- a/lib/exclusive-canonicalization.js
+++ b/lib/exclusive-canonicalization.js
@@ -48,7 +48,7 @@ class ExclusiveCanonicalization {
     return attr1.localeCompare(attr2);
   }
 
-  renderAttrs(node, defaultNS) {
+  renderAttrs(node) {
     let i;
     let attr;
     const res = [];
@@ -183,7 +183,7 @@ class ExclusiveCanonicalization {
       defaultNsForPrefix,
       inclusiveNamespacesPrefixList
     );
-    const res = ["<", node.tagName, ns.rendered, this.renderAttrs(node, ns.newDefaultNs), ">"];
+    const res = ["<", node.tagName, ns.rendered, this.renderAttrs(node), ">"];
 
     for (i = 0; i < node.childNodes.length; ++i) {
       pfxCopy = prefixesInScope.slice(0);

--- a/test/hmac-tests.js
+++ b/test/hmac-tests.js
@@ -2,7 +2,6 @@ const crypto = require("../index");
 const xpath = require("xpath");
 const xmldom = require("@xmldom/xmldom");
 const fs = require("fs");
-const { sign } = require("crypto");
 const expect = require("chai").expect;
 
 describe("HMAC tests", function () {


### PR DESCRIPTION
- Flag `no-unused-vars` violations as errors
- Remove spurious import in HMAC tests
- Remove spurious namespace arg to `renderAttrs()`