### PR TITLE
Expand the options, move idmode into options, fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,11 +36,17 @@ type SignatureAlgorithmType =
  * Options for the SignedXml constructor.
  */
 type SignedXmlOptions = {
-  canonicalizationAlgorithm?: TransformAlgorithmType;
-  inclusiveNamespacesPrefixList?: string;
+  idMode?: "wssecurity";
   idAttribute?: string;
-  implicitTransforms?: ReadonlyArray<TransformAlgorithmType>;
+  privateKey?: crypto.KeyLike;
+  publicCert?: crypto.KeyLike;
   signatureAlgorithm?: SignatureAlgorithmType;
+  canonicalizationAlgorithm?: CanonicalizationAlgorithmType;
+  inclusiveNamespacesPrefixList?: string;
+  implicitTransforms?: ReadonlyArray<TransformAlgorithmType>;
+  keyInfoAttributes?: { [attrName: string]: string };
+  getKeyInfoContent?(args?: GetKeyInfoContentArgs): string | null;
+  getCertFromKeyInfo?(keyInfo: string): string | null;
 };
 
 type CanonicalizationOrTransformationAlgorithmProcessOptions = {
@@ -186,8 +192,6 @@ export class SignedXml {
   canonicalizationAlgorithm: TransformAlgorithmType;
   // It specifies a list of namespace prefixes that should be considered "inclusive" during the canonicalization process.
   inclusiveNamespacesPrefixList: string;
-  // The structure for managing keys and KeyInfo section in XML data. See {@link KeyInfoProvider}
-  keyInfoProvider: KeyInfoProvider;
   // Specifies the data to be signed within an XML document. See {@link Reference}
   references: Reference[];
   // One of the supported signature algorithms. See {@link SignatureAlgorithmType}
@@ -200,10 +204,9 @@ export class SignedXml {
 
   /**
    * The SignedXml constructor provides an abstraction for sign and verify xml documents. The object is constructed using
-   * @param idMode  if the value of "wssecurity" is passed it will create/validate id's with the ws-security namespace.
-   * @param options {@link SignedXmlOptions
+   * @param options {@link SignedXmlOptions}
    */
-  constructor(idMode?: "wssecurity" | null, options?: SignedXmlOptions);
+  constructor(options?: SignedXmlOptions);
 
   /**
    * Due to key-confusion issues, it's risky to have both hmac
@@ -344,17 +347,17 @@ export class SignedXml {
   getCertFromKeyInfo(keyInfo: string): string | null;
 }
 
-export class Utils {
+export declare module utils {
   /**
    * @param pem The PEM-encoded base64 certificate to strip headers from
    */
-  static pemToDer(pem: string): string;
+  export function pemToDer(pem: string): string;
 
   /**
    * @param der The DER-encoded base64 certificate to add PEM headers too
    * @param pemLabel The label of the header and footer to add
    */
-  static derToPem(
+  export function derToPem(
     der: string,
     pemLabel: ["CERTIFICATE" | "PRIVATE KEY" | "RSA PUBLIC KEY"]
   ): string;
@@ -373,12 +376,12 @@ export class Utils {
    *  - normalize line length to maximum of 64 characters
    *  - ensure that 'preeb' has line ending '\n'
    *
-   * With couple of notes:
+   * With a couple of notes:
    *  - 'eol' is normalized to '\n'
    *
    * @param pem The PEM string to normalize to RFC7468 'stricttextualmsg' definition
    */
-  static normalizePem(pem: string): string;
+  export function normalizePem(pem: string): string;
 
   /**
    * PEM format has wide range of usages, but this library
@@ -393,9 +396,9 @@ export class Utils {
    *  - 'preeb' and 'posteb' lines are limited to 64 characters, but
    *     should not cause any issues in context of PKIX, PKCS and CMS.
    */
-  PEM_FORMAT_REGEX: RegExp;
-  EXTRACT_X509_CERTS: RegExp;
-  BASE64_REGEX: RegExp;
+  export const EXTRACT_X509_CERTS: RegExp;
+  export const PEM_FORMAT_REGEX: RegExp;
+  export const BASE64_REGEX: RegExp;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const select = require("xpath").select;
+const utils = require("./lib/utils");
 
 module.exports = require("./lib/signed-xml");
 module.exports.xpath = function (node, xpath) {
   return select(xpath, node);
 };
+module.exports.utils = utils;

--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -11,18 +11,42 @@ const signatureAlgorithms = require("./signature-algorithms");
  * @type {import ("../index.d.ts").SignedXml}
  */
 class SignedXml {
-  constructor(idMode, options = {}) {
-    this.options = options;
-    this.idMode = idMode;
+  /** @param {import("../index.d.ts").SignedXmlOptions} [options={}] */
+  constructor(options = {}) {
+    const {
+      idMode,
+      idAttribute,
+      privateKey,
+      publicCert,
+      signatureAlgorithm,
+      canonicalizationAlgorithm,
+      inclusiveNamespacesPrefixList,
+      implicitTransforms,
+      keyInfoAttributes,
+      getKeyInfoContent,
+      getCertFromKeyInfo,
+    } = options;
+
+    // Options
+    this.idMode = idMode || null;
+    this.idAttributes = ["Id", "ID", "id"];
+    if (idAttribute) {
+      this.idAttributes.unshift(idAttribute);
+    }
+    this.privateKey = privateKey || null;
+    this.publicCert = publicCert || null;
+    this.signatureAlgorithm = signatureAlgorithm || "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+    this.canonicalizationAlgorithm =
+      canonicalizationAlgorithm || "http://www.w3.org/2001/10/xml-exc-c14n#";
+    this.inclusiveNamespacesPrefixList = inclusiveNamespacesPrefixList || "";
+    this.implicitTransforms = implicitTransforms || [];
+    this.keyInfoAttributes = keyInfoAttributes || {};
+    this.getKeyInfoContent = getKeyInfoContent || SignedXml.getKeyInfoContent;
+    this.getCertFromKeyInfo = getCertFromKeyInfo || SignedXml.getCertFromKeyInfo;
+
+    // Internal state
     this.references = [];
     this.id = 0;
-    this.privateKey = null;
-    this.publicCert = null;
-    this.signatureAlgorithm =
-      this.options.signatureAlgorithm || "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
-    this.canonicalizationAlgorithm =
-      this.options.canonicalizationAlgorithm || "http://www.w3.org/2001/10/xml-exc-c14n#";
-    this.inclusiveNamespacesPrefixList = this.options.inclusiveNamespacesPrefixList || "";
     this.signedXml = "";
     this.signatureXml = "";
     this.signatureNode = null;
@@ -30,14 +54,6 @@ class SignedXml {
     this.originalXmlWithIds = "";
     this.validationErrors = [];
     this.keyInfo = null;
-    this.idAttributes = ["Id", "ID", "id"];
-    if (this.options.idAttribute) {
-      this.idAttributes.unshift(this.options.idAttribute);
-    }
-    this.implicitTransforms = this.options.implicitTransforms || [];
-    this.getKeyInfoContent = SignedXml.getKeyInfoContent;
-    this.getCertFromKeyInfo = SignedXml.getCertFromKeyInfo;
-    this.keyInfoAttributes = {};
 
     this.CanonicalizationAlgorithms = {
       "http://www.w3.org/TR/2001/REC-xml-c14n-20010315": c14n.C14nCanonicalization,
@@ -65,7 +81,7 @@ class SignedXml {
   }
 
   /**
-   * Due to key-confusion issues, its risky to have both hmac
+   * Due to key-confusion issues, it's risky to have both hmac
    * and digital signature algos enabled at the same time.
    * This enables HMAC and disables other signing algos.
    */


### PR DESCRIPTION
Refactored the SignedXml class to accept all options through a single options object, enhancing the flexibility and readability of the code. This change includes migrating the idMode argument into the options object for better consistency.

Also fixed some broken types, and updated README to be consistent with these changes.