### PR TITLE
Exports C14nCanonicalization, ExclusiveCanonicalization

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 var select = require("xpath").select;
 
 module.exports = require("./lib/signed-xml");
+module.exports.C14nCanonicalization = require("./lib/c14n-canonicalization").C14nCanonicalization;
+module.exports.C14nCanonicalizationWithComments = require("./lib/c14n-canonicalization").C14nCanonicalizationWithComments;
+module.exports.ExclusiveCanonicalization = require("./lib/exclusive-canonicalization").ExclusiveCanonicalization;
+module.exports.ExclusiveCanonicalizationWithComments = require("./lib/exclusive-canonicalization").ExclusiveCanonicalizationWithComments;
 module.exports.xpath = function (node, xpath) {
   return select(xpath, node);
 };


### PR DESCRIPTION
Closes #331

This allow us to do
```ts
const C14nCanonicalization = require('xml-crypto').C14nCanonicalization 
const ExclusiveCanonicalization= require('xml-crypto').ExclusiveCanonicalization

// Use Example 
const DOMParser = require("@xmldom/xmldom").DOMParser
let xml_string = '<root><child>123</child></root>'
let documentElement= (new DOMParser()).parseFromString(xml_string).documentElement

// C14nCanonicalization
console.log( (new C14nCanonicalization()).process(documentElement, {}).toString() )
// ExclusiveCanonicalization
console.log( (new ExclusiveCanonicalization()).process(documentElement, {}).toString() )
```
This is not a breaking change
Any correction I will try to correct immediately