### PR TITLE
Fix validationErrors type

### DIFF
--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -69,7 +69,7 @@ export class SignedXml {
   /**
    * Contains validation errors (if any) after {@link checkSignature} method is called
    */
-  private validationErrors: string[] = [];
+  validationErrors: string[] = [];
   private keyInfo: Node | null = null;
 
   /**


### PR DESCRIPTION
In the examples it is shown that the value can be read. Therefore, the value should not be marked as private.