### PR TITLE
Consistently reference `xmldom`

### DIFF
--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -15,7 +15,7 @@ import type {
 } from "./types";
 
 import * as xpath from "xpath";
-import { DOMParser as Dom } from "@xmldom/xmldom";
+import * as xmldom from "@xmldom/xmldom";
 import * as utils from "./utils";
 import * as c14n from "./c14n-canonicalization";
 import * as execC14n from "./exclusive-canonicalization";
@@ -246,7 +246,7 @@ export class SignedXml {
     this.validationErrors = [];
     this.signedXml = xml;
 
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
 
     if (!this.validateReferences(doc)) {
       if (!callback) {
@@ -453,7 +453,7 @@ export class SignedXml {
    */
   loadSignature(signatureNode: Node | string): void {
     if (typeof signatureNode === "string") {
-      this.signatureNode = signatureNode = new Dom().parseFromString(signatureNode);
+      this.signatureNode = signatureNode = new xmldom.DOMParser().parseFromString(signatureNode);
     } else {
       this.signatureNode = signatureNode;
     }
@@ -688,7 +688,7 @@ export class SignedXml {
       options = (options ?? {}) as ComputeSignatureOptions;
     }
 
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
     let xmlNsAttr = "xmlns";
     const signatureAttrs: string[] = [];
     let currentPrefix: string;
@@ -758,7 +758,7 @@ export class SignedXml {
     // A trick to remove the namespaces that already exist in the xml
     // This only works if the prefix and namespace match with those in the xml
     const dummySignatureWrapper = `<Dummy ${existingPrefixesString}>${signatureXml}</Dummy>`;
-    const nodeXml = new Dom().parseFromString(dummySignatureWrapper);
+    const nodeXml = new xmldom.DOMParser().parseFromString(dummySignatureWrapper);
 
     // Because we are using a dummy wrapper hack described above, we know there will be a `firstChild`
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -1027,7 +1027,7 @@ export class SignedXml {
     //we need to wrap the info in a dummy signature since it contains the default namespace.
     const dummySignatureWrapper = `<${prefix}Signature ${xmlNsAttr}="http://www.w3.org/2000/09/xmldsig#">${signatureValueXml}</${prefix}Signature>`;
 
-    const doc = new Dom().parseFromString(dummySignatureWrapper);
+    const doc = new xmldom.DOMParser().parseFromString(dummySignatureWrapper);
 
     // Because we are using a dummy wrapper hack described above, we know there will be a `firstChild`
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -220,7 +220,7 @@ function isElementSubset(docSubset: Node[]): docSubset is Element[] {
  * Extract ancestor namespaces in order to import it to root of document subset
  * which is being canonicalized for non-exclusive c14n.
  *
- * @param {object} doc - Usually a product from `new DOMParser().parseFromString()`
+ * @param {object} doc - Usually a product from `new xmldom.DOMParser().parseFromString()`
  * @param {string} docSubsetXpath - xpath query to get document subset being canonicalized
  * @param {object} namespaceResolver - xpath namespace resolver
  * @returns {Array} i.e. [{prefix: "saml", namespaceURI: "urn:oasis:names:tc:SAML:2.0:assertion"}]

--- a/test/c14n-non-exclusive-unit-tests.spec.ts
+++ b/test/c14n-non-exclusive-unit-tests.spec.ts
@@ -1,12 +1,12 @@
 import { expect } from "chai";
 
 import { C14nCanonicalization } from "../src/c14n-canonicalization";
-import { DOMParser as Dom } from "@xmldom/xmldom";
+import * as xmldom from "@xmldom/xmldom";
 import * as xpath from "xpath";
 import * as utils from "../src/utils";
 
 const test_C14nCanonicalization = function (xml, xpathArg, expected) {
-  const doc = new Dom().parseFromString(xml);
+  const doc = new xmldom.DOMParser().parseFromString(xml);
   const elem = xpath.select1(xpathArg, doc);
   const can = new C14nCanonicalization();
   const result = can
@@ -20,7 +20,7 @@ const test_C14nCanonicalization = function (xml, xpathArg, expected) {
 };
 
 const test_findAncestorNs = function (xml, xpath, expected) {
-  const doc = new Dom().parseFromString(xml);
+  const doc = new xmldom.DOMParser().parseFromString(xml);
   const result = utils.findAncestorNs(doc, xpath);
 
   expect(result).to.deep.equal(expected);

--- a/test/c14nWithComments-unit-tests.spec.ts
+++ b/test/c14nWithComments-unit-tests.spec.ts
@@ -1,12 +1,12 @@
 import { expect } from "chai";
 
 import { ExclusiveCanonicalizationWithComments as c14nWithComments } from "../src/exclusive-canonicalization";
-import { DOMParser as Dom } from "@xmldom/xmldom";
+import * as xmldom from "@xmldom/xmldom";
 import * as xpath from "xpath";
 import { SignedXml } from "../src/index";
 
 const compare = function (xml, xpathArg, expected, inclusiveNamespacesPrefixList?: string[]) {
-  const doc = new Dom().parseFromString(xml);
+  const doc = new xmldom.DOMParser().parseFromString(xml);
   const elem = xpath.select1(xpathArg, doc);
   const can = new c14nWithComments();
   const result = can.process(elem, { inclusiveNamespacesPrefixList }).toString();
@@ -348,7 +348,7 @@ describe("Exclusive canonicalization with comments", function () {
 
   it("Multiple Canonicalization with namespace definition outside of signed element", function () {
     //var doc = new Dom().parseFromString("<x xmlns:p=\"myns\"><p:y><ds:Signature xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"></ds:Signature></p:y></x>")
-    const doc = new Dom().parseFromString('<x xmlns:p="myns"><p:y></p:y></x>');
+    const doc = new xmldom.DOMParser().parseFromString('<x xmlns:p="myns"><p:y></p:y></x>');
     const node = xpath.select1("//*[local-name(.)='y']", doc);
     const sig = new SignedXml();
     // @ts-expect-error FIXME
@@ -368,7 +368,7 @@ describe("Exclusive canonicalization with comments", function () {
     //   in a document.
     const xml =
       '<x><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" /><y><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" /></y></x>';
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
     const node = xpath.select1("//*[local-name(.)='y']", doc);
     const sig = new SignedXml();
     const transforms = ["http://www.w3.org/2000/09/xmldsig#enveloped-signature"];

--- a/test/canonicalization-unit-tests.spec.ts
+++ b/test/canonicalization-unit-tests.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 import { ExclusiveCanonicalization } from "../src/exclusive-canonicalization";
-import { DOMParser as Dom } from "@xmldom/xmldom";
+import * as xmldom from "@xmldom/xmldom";
 import * as xpath from "xpath";
 import { SignedXml } from "../src/index";
 
@@ -12,7 +12,7 @@ const compare = function (
   inclusiveNamespacesPrefixList?: string[],
   defaultNsForPrefix?: Record<string, string>,
 ) {
-  const doc = new Dom().parseFromString(xml);
+  const doc = new xmldom.DOMParser().parseFromString(xml);
   const elem = xpath.select1(xpathArg, doc);
   const can = new ExclusiveCanonicalization();
   const result = can
@@ -397,7 +397,7 @@ describe("Canonicalization unit tests", function () {
 
   it("Multiple Canonicalization with namespace definition outside of signed element", function () {
     //var doc = new Dom().parseFromString("<x xmlns:p=\"myns\"><p:y><ds:Signature xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"></ds:Signature></p:y></x>")
-    const doc = new Dom().parseFromString('<x xmlns:p="myns"><p:y></p:y></x>');
+    const doc = new xmldom.DOMParser().parseFromString('<x xmlns:p="myns"><p:y></p:y></x>');
     const node = xpath.select1("//*[local-name(.)='y']", doc);
     const sig = new SignedXml();
     // @ts-expect-error FIXME
@@ -417,7 +417,7 @@ describe("Canonicalization unit tests", function () {
     //   in a document.
     const xml =
       '<x><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" /><y><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" /></y></x>';
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
     const node = xpath.select1("//*[local-name(.)='y']", doc);
     const sig = new SignedXml();
     const transforms = ["http://www.w3.org/2000/09/xmldsig#enveloped-signature"];

--- a/test/signature-integration-tests.spec.ts
+++ b/test/signature-integration-tests.spec.ts
@@ -1,5 +1,5 @@
 import * as xpath from "xpath";
-import { DOMParser as Dom } from "@xmldom/xmldom";
+import * as xmldom from "@xmldom/xmldom";
 import { SignedXml } from "../src/index";
 import * as fs from "fs";
 import { expect } from "chai";
@@ -103,7 +103,7 @@ describe("Signature integration tests", function () {
     //   the xmldom-fork-fixed library which can pass {ignoreWhiteSpace: true} into the Dom constructor.
     xml = xml.replace(/>\s*</g, "><");
 
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
     // @ts-expect-error FIXME
     xml = doc.firstChild.toString();
 
@@ -122,7 +122,7 @@ describe("Signature integration tests", function () {
 
   it("signature with inclusive namespaces", function () {
     let xml = fs.readFileSync("./test/static/signature_with_inclusivenamespaces.xml", "utf-8");
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
     // @ts-expect-error FIXME
     xml = doc.firstChild.toString();
 
@@ -144,7 +144,7 @@ describe("Signature integration tests", function () {
       "./test/static/signature_with_inclusivenamespaces_lines.xml",
       "utf-8",
     );
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
     // @ts-expect-error FIXME
     xml = doc.firstChild.toString();
 
@@ -166,7 +166,7 @@ describe("Signature integration tests", function () {
       "./test/static/signature_with_inclusivenamespaces_lines_windows.xml",
       "utf-8",
     );
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
     // @ts-expect-error FIXME
     xml = doc.firstChild.toString();
 
@@ -193,7 +193,7 @@ describe("Signature integration tests", function () {
 
     const signed = sig.getSignedXml();
 
-    const doc = new Dom().parseFromString(signed);
+    const doc = new xmldom.DOMParser().parseFromString(signed);
 
     /*
         Expecting this structure:

--- a/test/signature-unit-tests.spec.ts
+++ b/test/signature-unit-tests.spec.ts
@@ -1,5 +1,5 @@
 import * as xpath from "xpath";
-import { DOMParser as Dom } from "@xmldom/xmldom";
+import * as xmldom from "@xmldom/xmldom";
 import { SignedXml } from "../src/index";
 import * as fs from "fs";
 import * as crypto from "crypto";
@@ -7,7 +7,7 @@ import { expect } from "chai";
 
 describe("Signature unit tests", function () {
   function verifySignature(xml, mode) {
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
     const node = xpath.select1(
       "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']",
       doc,
@@ -34,7 +34,7 @@ describe("Signature unit tests", function () {
 
   function passLoadSignature(file, toString) {
     const xml = fs.readFileSync(file, "utf8");
-    const doc = new Dom().parseFromString(xml);
+    const doc = new xmldom.DOMParser().parseFromString(xml);
     const node = xpath.select1(
       "/*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']",
       doc,
@@ -102,7 +102,7 @@ describe("Signature unit tests", function () {
     sig.addReference({ xpath: "//*[local-name(.)='x']" });
     sig.computeSignature(xml);
     const signedXml = sig.getOriginalXmlWithIds();
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
     const attrs = xpath.select("//@*", doc);
     // @ts-expect-error FIXME
     expect(attrs.length, "wrong number of attributes").to.equal(2);
@@ -128,7 +128,7 @@ describe("Signature unit tests", function () {
 
     sig.computeSignature(xml);
     const signedXml = sig.getOriginalXmlWithIds();
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
 
     const op = nsMode === "equal" ? "=" : "!=";
 
@@ -158,7 +158,7 @@ describe("Signature unit tests", function () {
     });
 
     const signedXml = sig.getSignatureXml();
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
     const signatureNode = doc.documentElement;
 
     expect(attrs.Id, `Id attribute is not equal to the expected value: "${attrs.Id}"`).to.equal(
@@ -193,7 +193,7 @@ describe("Signature unit tests", function () {
     });
 
     const signedXml = sig.getSignatureXml();
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
     const references = xpath.select("//*[local-name(.)='Reference']", doc);
     // @ts-expect-error FIXME
     expect(references.length).to.equal(2);
@@ -225,7 +225,7 @@ describe("Signature unit tests", function () {
     sig.addReference({ xpath: "//*[local-name(.)='name']" });
     sig.computeSignature(xml);
 
-    const doc = new Dom().parseFromString(sig.getSignedXml());
+    const doc = new xmldom.DOMParser().parseFromString(sig.getSignedXml());
 
     expect(
       // @ts-expect-error FIXME
@@ -248,7 +248,7 @@ describe("Signature unit tests", function () {
       },
     });
 
-    const doc = new Dom().parseFromString(sig.getSignedXml());
+    const doc = new xmldom.DOMParser().parseFromString(sig.getSignedXml());
     const referenceNode = xpath.select1("/root/name", doc);
 
     expect(
@@ -272,7 +272,7 @@ describe("Signature unit tests", function () {
       },
     });
 
-    const doc = new Dom().parseFromString(sig.getSignedXml());
+    const doc = new xmldom.DOMParser().parseFromString(sig.getSignedXml());
     const referenceNode = xpath.select1("/root/name", doc);
 
     expect(
@@ -296,7 +296,7 @@ describe("Signature unit tests", function () {
       },
     });
 
-    const doc = new Dom().parseFromString(sig.getSignedXml());
+    const doc = new xmldom.DOMParser().parseFromString(sig.getSignedXml());
     const referenceNode = xpath.select1("/root/name", doc);
 
     expect(
@@ -320,7 +320,7 @@ describe("Signature unit tests", function () {
       },
     });
 
-    const doc = new Dom().parseFromString(sig.getSignedXml());
+    const doc = new xmldom.DOMParser().parseFromString(sig.getSignedXml());
     const referenceNode = xpath.select1("/root/name", doc);
 
     expect(
@@ -872,7 +872,7 @@ describe("Signature unit tests", function () {
 
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
     const URI = xpath.select1("//*[local-name(.)='Reference']/@URI", doc);
     // @ts-expect-error FIXME
     expect(URI.value, `uri should be empty but instead was ${URI.value}`).to.equal("");
@@ -959,7 +959,7 @@ describe("Signature unit tests", function () {
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
 
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
     const inclusiveNamespaces = xpath.select(
       "//*[local-name(.)='Reference']/*[local-name(.)='Transforms']/*[local-name(.)='Transform']/*[local-name(.)='InclusiveNamespaces']",
       doc.documentElement,
@@ -994,7 +994,7 @@ describe("Signature unit tests", function () {
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
 
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
     const inclusiveNamespaces = xpath.select(
       "//*[local-name(.)='Reference']/*[local-name(.)='Transforms']/*[local-name(.)='Transform']/*[local-name(.)='InclusiveNamespaces']",
       doc.documentElement,
@@ -1020,7 +1020,7 @@ describe("Signature unit tests", function () {
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
 
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
     const inclusiveNamespaces = xpath.select(
       "//*[local-name(.)='CanonicalizationMethod']/*[local-name(.)='InclusiveNamespaces']",
       doc.documentElement,
@@ -1056,7 +1056,7 @@ describe("Signature unit tests", function () {
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
 
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
     const inclusiveNamespaces = xpath.select(
       "//*[local-name(.)='CanonicalizationMethod']/*[local-name(.)='InclusiveNamespaces']",
       doc.documentElement,
@@ -1082,7 +1082,7 @@ describe("Signature unit tests", function () {
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
 
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
     const keyInfoElement = xpath.select("//*[local-name(.)='KeyInfo']", doc.documentElement);
     // @ts-expect-error FIXME
     expect(keyInfoElement.length, "KeyInfo element should exist").to.equal(1);
@@ -1111,7 +1111,7 @@ describe("Signature unit tests", function () {
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
 
-    const doc = new Dom().parseFromString(signedXml);
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
 
     const x509certificates = xpath.select(
       "//*[local-name(.)='X509Certificate']",


### PR DESCRIPTION
`xmldom` was referenced differently throughout the codebase. This refactors it to be referenced consistently.