### PR TITLE
Fix transform processing regression

### DIFF
--- a/src/c14n-canonicalization.ts
+++ b/src/c14n-canonicalization.ts
@@ -167,11 +167,14 @@ export class C14nCanonicalization implements CanonicalizationOrTransformationAlg
     return { rendered: res.join(""), newDefaultNs };
   }
 
-  processInner(node: Node, prefixesInScope, defaultNs, defaultNsForPrefix, ancestorNamespaces) {
+  /**
+   * @param node Node
+   */
+  processInner(node, prefixesInScope, defaultNs, defaultNsForPrefix, ancestorNamespaces) {
     if (xpath.isComment(node)) {
       return this.renderComment(node);
     }
-    if (xpath.isComment(node)) {
+    if (node.data) {
       return utils.encodeSpecialCharactersInText(node.data);
     }
 
@@ -198,7 +201,7 @@ export class C14nCanonicalization implements CanonicalizationOrTransformationAlg
       return res.join("");
     }
 
-    return "";
+    throw new Error(`Unable to canonicalize node type: ${node.nodeType}`);
   }
 
   // Thanks to deoxxa/xml-c14n for comment renderer
@@ -247,7 +250,7 @@ export class C14nCanonicalization implements CanonicalizationOrTransformationAlg
    * @param node
    * @api public
    */
-  process(node: Node, options: CanonicalizationOrTransformationAlgorithmProcessOptions) {
+  process(node: Node, options: CanonicalizationOrTransformationAlgorithmProcessOptions): string {
     options = options || {};
     const defaultNs = options.defaultNs || "";
     const defaultNsForPrefix = options.defaultNsForPrefix || {};

--- a/src/enveloped-signature.ts
+++ b/src/enveloped-signature.ts
@@ -8,7 +8,7 @@ import type {
 
 export class EnvelopedSignature implements CanonicalizationOrTransformationAlgorithm {
   includeComments = false;
-  process(node: Node, options: CanonicalizationOrTransformationAlgorithmProcessOptions) {
+  process(node: Node, options: CanonicalizationOrTransformationAlgorithmProcessOptions): Node {
     if (null == options.signatureNode) {
       const signature = xpath.select1(
         "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']",

--- a/src/exclusive-canonicalization.ts
+++ b/src/exclusive-canonicalization.ts
@@ -167,6 +167,9 @@ export class ExclusiveCanonicalization implements CanonicalizationOrTransformati
     return { rendered: res.join(""), newDefaultNs: newDefaultNs };
   }
 
+  /**
+   * @param node Node
+   */
   processInner(
     node,
     prefixesInScope,
@@ -181,32 +184,36 @@ export class ExclusiveCanonicalization implements CanonicalizationOrTransformati
       return utils.encodeSpecialCharactersInText(node.data);
     }
 
-    let i;
-    let pfxCopy;
-    const ns = this.renderNs(
-      node,
-      prefixesInScope,
-      defaultNs,
-      defaultNsForPrefix,
-      inclusiveNamespacesPrefixList,
-    );
-    const res = ["<", node.tagName, ns.rendered, this.renderAttrs(node), ">"];
-
-    for (i = 0; i < node.childNodes.length; ++i) {
-      pfxCopy = prefixesInScope.slice(0);
-      res.push(
-        this.processInner(
-          node.childNodes[i],
-          pfxCopy,
-          ns.newDefaultNs,
-          defaultNsForPrefix,
-          inclusiveNamespacesPrefixList,
-        ),
+    if (xpath.isElement(node)) {
+      let i;
+      let pfxCopy;
+      const ns = this.renderNs(
+        node,
+        prefixesInScope,
+        defaultNs,
+        defaultNsForPrefix,
+        inclusiveNamespacesPrefixList,
       );
+      const res = ["<", node.tagName, ns.rendered, this.renderAttrs(node), ">"];
+
+      for (i = 0; i < node.childNodes.length; ++i) {
+        pfxCopy = prefixesInScope.slice(0);
+        res.push(
+          this.processInner(
+            node.childNodes[i],
+            pfxCopy,
+            ns.newDefaultNs,
+            defaultNsForPrefix,
+            inclusiveNamespacesPrefixList,
+          ),
+        );
+      }
+
+      res.push("</", node.tagName, ">");
+      return res.join("");
     }
 
-    res.push("</", node.tagName, ">");
-    return res.join("");
+    throw new Error(`Unable to exclusive canonicalize node type: ${node.nodeType}`);
   }
 
   // Thanks to deoxxa/xml-c14n for comment renderer
@@ -250,13 +257,11 @@ export class ExclusiveCanonicalization implements CanonicalizationOrTransformati
   }
 
   /**
-   * Perform canonicalization of the given node
+   * Perform canonicalization of the given element node
    *
-   * @param {Node} node
-   * @return {String}
    * @api public
    */
-  process(node, options: CanonicalizationOrTransformationAlgorithmProcessOptions) {
+  process(elem: Element, options: CanonicalizationOrTransformationAlgorithmProcessOptions): string {
     options = options || {};
     let inclusiveNamespacesPrefixList = options.inclusiveNamespacesPrefixList || [];
     const defaultNs = options.defaultNs || "";
@@ -267,7 +272,7 @@ export class ExclusiveCanonicalization implements CanonicalizationOrTransformati
      * If the inclusiveNamespacesPrefixList has not been explicitly provided then look it up in CanonicalizationMethod/InclusiveNamespaces
      */
     if (!utils.isArrayHasLength(inclusiveNamespacesPrefixList)) {
-      const CanonicalizationMethod = utils.findChildren(node, "CanonicalizationMethod");
+      const CanonicalizationMethod = utils.findChildren(elem, "CanonicalizationMethod");
       if (CanonicalizationMethod.length !== 0) {
         const inclusiveNamespaces = utils.findChildren(
           CanonicalizationMethod[0],
@@ -289,7 +294,7 @@ export class ExclusiveCanonicalization implements CanonicalizationOrTransformati
         if (ancestorNamespaces) {
           ancestorNamespaces.forEach(function (ancestorNamespace) {
             if (prefix === ancestorNamespace.prefix) {
-              node.setAttributeNS(
+              elem.setAttributeNS(
                 "http://www.w3.org/2000/xmlns/",
                 `xmlns:${prefix}`,
                 ancestorNamespace.namespaceURI,
@@ -301,7 +306,7 @@ export class ExclusiveCanonicalization implements CanonicalizationOrTransformati
     }
 
     const res = this.processInner(
-      node,
+      elem,
       [],
       defaultNs,
       defaultNsForPrefix,

--- a/test/c14nWithComments-unit-tests.spec.ts
+++ b/test/c14nWithComments-unit-tests.spec.ts
@@ -9,9 +9,12 @@ const compare = function (xml, xpathArg, expected, inclusiveNamespacesPrefixList
   const doc = new xmldom.DOMParser().parseFromString(xml);
   const elem = xpath.select1(xpathArg, doc);
   const can = new c14nWithComments();
-  const result = can.process(elem, { inclusiveNamespacesPrefixList }).toString();
-
-  expect(result).to.equal(expected);
+  if (xpath.isElement(elem)) {
+    const result = can.process(elem, { inclusiveNamespacesPrefixList }).toString();
+    expect(result).to.equal(expected);
+  } else {
+    throw new Error("Element not found.");
+  }
 };
 
 describe("Exclusive canonicalization with comments", function () {

--- a/test/canonicalization-unit-tests.spec.ts
+++ b/test/canonicalization-unit-tests.spec.ts
@@ -15,14 +15,18 @@ const compare = function (
   const doc = new xmldom.DOMParser().parseFromString(xml);
   const elem = xpath.select1(xpathArg, doc);
   const can = new ExclusiveCanonicalization();
-  const result = can
-    .process(elem, {
-      inclusiveNamespacesPrefixList,
-      defaultNsForPrefix,
-    })
-    .toString();
+  if (xpath.isElement(elem)) {
+    const result = can
+      .process(elem, {
+        inclusiveNamespacesPrefixList,
+        defaultNsForPrefix,
+      })
+      .toString();
 
-  expect(expected).to.equal(result);
+    expect(expected).to.equal(result);
+  } else {
+    throw new Error("Invalid element");
+  }
 };
 
 describe("Canonicalization unit tests", function () {

--- a/test/signature-unit-tests.spec.ts
+++ b/test/signature-unit-tests.spec.ts
@@ -877,6 +877,10 @@ describe("Signature unit tests", function () {
     passValidSignature("./test/static/valid_signature_with_unused_prefixes.xml");
   });
 
+  it("verifies valid signature without transforms element", function () {
+    passValidSignature("./test/static/valid_signature_without_transforms_element.xml");
+  });
+
   it("fails invalid signature - signature value", function () {
     failInvalidSignature("./test/static/invalid_signature - signature value.xml");
   });
@@ -916,6 +920,10 @@ describe("Signature unit tests", function () {
       "./test/static/invalid_signature - wsu - changed content.xml",
       "wssecurity",
     );
+  });
+
+  it("fails invalid signature without transforms element", function () {
+    failInvalidSignature("./test/static/invalid_signature_without_transforms_element.xml");
   });
 
   it("allow empty reference uri when signing", function () {

--- a/test/static/invalid_signature_without_transforms_element.xml
+++ b/test/static/invalid_signature_without_transforms_element.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<library><book ID="bookid"><name>some tampered text</name></book><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/><Reference URI="#bookid"><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/><DigestValue>LsMoqo1d6Sqh8DKLp00MK0fSBDA=</DigestValue></Reference></SignedInfo><SignatureValue>OR1SYcyU18qELj+3DX/bW/r5DqueuyPAnNFEh3hNKFaj8ZKLB/mdsR9w8GDBCmZ2
+lsCTEvJqWC37oF8rm2eBSonNbdBnA+TM6Y22C8rffVzaoM3zpNoeWMH2LwFmpdKB
+UXOMWVExEaz/s4fOcyv1ajVuk42I3nl0xcD95+i7PjY=</SignatureValue></Signature></library>

--- a/test/static/valid_signature_without_transforms_element.xml
+++ b/test/static/valid_signature_without_transforms_element.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<library><book ID="bookid"><name>some text</name></book><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/><Reference URI="#bookid"><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/><DigestValue>LsMoqo1d6Sqh8DKLp00MK0fSBDA=</DigestValue></Reference></SignedInfo><SignatureValue>OR1SYcyU18qELj+3DX/bW/r5DqueuyPAnNFEh3hNKFaj8ZKLB/mdsR9w8GDBCmZ2
+lsCTEvJqWC37oF8rm2eBSonNbdBnA+TM6Y22C8rffVzaoM3zpNoeWMH2LwFmpdKB
+UXOMWVExEaz/s4fOcyv1ajVuk42I3nl0xcD95+i7PjY=</SignatureValue></Signature></library>


### PR DESCRIPTION
There was a bug introduced in the 4.x release of `xml-crypto` whereby transforms weren't added in all the cases they were supposed to.

This includes code from the [comment](https://github.com/node-saml/xml-crypto/issues/378#issuecomment-1687120300) by @srd90.

Closes #378 