### PR TITLE
Enforce consistent transform processing

### DIFF
--- a/test/c14nWithComments-unit-tests.spec.ts
+++ b/test/c14nWithComments-unit-tests.spec.ts
@@ -347,8 +347,9 @@ describe("Exclusive canonicalization with comments", function () {
   });
 
   it("Multiple Canonicalization with namespace definition outside of signed element", function () {
-    //var doc = new Dom().parseFromString("<x xmlns:p=\"myns\"><p:y><ds:Signature xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"></ds:Signature></p:y></x>")
-    const doc = new xmldom.DOMParser().parseFromString('<x xmlns:p="myns"><p:y></p:y></x>');
+    const doc = new xmldom.DOMParser().parseFromString(
+      '<x xmlns:p="myns"><p:y><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"></ds:Signature></p:y></x>',
+    );
     const node = xpath.select1("//*[local-name(.)='y']", doc);
     if (xpath.isNodeLike(node)) {
       const sig = new SignedXml();
@@ -365,7 +366,7 @@ describe("Exclusive canonicalization with comments", function () {
     }
   });
 
-  it("Enveloped-signature canonicalization respects currentnode", function () {
+  it("Enveloped-signature canonicalization respects current node", function () {
     // older versions of enveloped-signature removed the first signature in the whole doc, but should
     //   be the signature inside the current node if we want to be able to verify multiple signatures
     //   in a document.


### PR DESCRIPTION
During a refactor, a bug was introduced that caused inconsistent processing of transforms. This PR fixes this inconsistency and adds a check to make sure that another inconsistency, that of trying to transform a string, isn't introduced. Ideally, the `xpath` library would throw if a `string` is passed instead of a `Node`, which would solve this problem.

This addresses an issue observed by @srd90 in the bottom part of his comment [here](https://github.com/node-saml/xml-crypto/issues/378#issuecomment-1687120300).