### PR TITLE
Add support for directly querying a node to see if it has passed validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,27 @@ A pre requisite it to have [openssl](http://www.openssl.org/) installed and its 
 
 ### Canonicalization and Transformation Algorithms
 
-- Canonicalization http://www.w3.org/TR/2001/REC-xml-c14n-20010315
-- Canonicalization with comments http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments
-- Exclusive Canonicalization http://www.w3.org/2001/10/xml-exc-c14n#
-- Exclusive Canonicalization with comments http://www.w3.org/2001/10/xml-exc-c14n#WithComments
-- Enveloped Signature transform http://www.w3.org/2000/09/xmldsig#enveloped-signature
+- Canonicalization <http://www.w3.org/TR/2001/REC-xml-c14n-20010315>
+- Canonicalization with comments <http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments>
+- Exclusive Canonicalization <http://www.w3.org/2001/10/xml-exc-c14n#>
+- Exclusive Canonicalization with comments <http://www.w3.org/2001/10/xml-exc-c14n#WithComments>
+- Enveloped Signature transform <http://www.w3.org/2000/09/xmldsig#enveloped-signature>
 
 ### Hashing Algorithms
 
-- SHA1 digests http://www.w3.org/2000/09/xmldsig#sha1
-- SHA256 digests http://www.w3.org/2001/04/xmlenc#sha256
-- SHA512 digests http://www.w3.org/2001/04/xmlenc#sha512
+- SHA1 digests <http://www.w3.org/2000/09/xmldsig#sha1>
+- SHA256 digests <http://www.w3.org/2001/04/xmlenc#sha256>
+- SHA512 digests <http://www.w3.org/2001/04/xmlenc#sha512>
 
 ### Signature Algorithms
 
-- RSA-SHA1 http://www.w3.org/2000/09/xmldsig#rsa-sha1
-- RSA-SHA256 http://www.w3.org/2001/04/xmldsig-more#rsa-sha256
-- RSA-SHA512 http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
+- RSA-SHA1 <http://www.w3.org/2000/09/xmldsig#rsa-sha1>
+- RSA-SHA256 <http://www.w3.org/2001/04/xmldsig-more#rsa-sha256>
+- RSA-SHA512 <http://www.w3.org/2001/04/xmldsig-more#rsa-sha512>
 
 HMAC-SHA1 is also available but it is disabled by default
 
-- HMAC-SHA1 http://www.w3.org/2000/09/xmldsig#hmac-sha1
+- HMAC-SHA1 <http://www.w3.org/2000/09/xmldsig#hmac-sha1>
 
 to enable HMAC-SHA1, call `enableHMAC()` on your instance of `SignedXml`.
 
@@ -51,11 +51,11 @@ signature algorithms enabled at same time.
 
 by default the following algorithms are used:
 
-_Canonicalization/Transformation Algorithm:_ Exclusive Canonicalization http://www.w3.org/2001/10/xml-exc-c14n#
+_Canonicalization/Transformation Algorithm:_ Exclusive Canonicalization <http://www.w3.org/2001/10/xml-exc-c14n#>
 
-_Hashing Algorithm:_ SHA1 digest http://www.w3.org/2000/09/xmldsig#sha1
+_Hashing Algorithm:_ SHA1 digest <http://www.w3.org/2000/09/xmldsig#sha1>
 
-_Signature Algorithm:_ RSA-SHA1 http://www.w3.org/2000/09/xmldsig#rsa-sha1
+_Signature Algorithm:_ RSA-SHA1 <http://www.w3.org/2000/09/xmldsig#rsa-sha1>
 
 [You are able to extend xml-crypto with custom algorithms.](#customizing-algorithms)
 
@@ -153,18 +153,37 @@ In order to protect from some attacks we must check the content we want to use i
 
 ```javascript
 // Roll your own
-var elem = xpath.select("/xpath_to_interesting_element", doc);
-var uri = sig.references[0].uri; // might not be 0 - depending on the document you verify
-var id = uri[0] === "#" ? uri.substring(1) : uri;
-if (elem.getAttribute("ID") != id && elem.getAttribute("Id") != id && elem.getAttribute("id") != id)
-  throw new Error("the interesting element was not the one verified by the signature");
+const elem = xpath.select("/xpath_to_interesting_element", doc);
+const uri = sig.references[0].uri; // might not be 0; it depends on the document
+const id = uri[0] === "#" ? uri.substring(1) : uri;
+if (
+  elem.getAttribute("ID") != id &&
+  elem.getAttribute("Id") != id &&
+  elem.getAttribute("id") != id
+) {
+  throw new Error("The interesting element was not the one verified by the signature");
+}
+
+// Get the validated element directly from a reference
+const elem = sig.references[0].getValidatedElement(); // might not be 0; it depends on the document
+const matchingReference = xpath.select1("/xpath_to_interesting_element", elem);
+if (!isDomNode.isNodeLike(matchingReference)) {
+  throw new Error("The interesting element was not the one verified by the signature");
+}
 
 // Use the built-in method
-let elem = xpath.select("/xpath_to_interesting_element", doc);
+const elem = xpath.select1("/xpath_to_interesting_element", doc);
 try {
   const matchingReference = sig.validateElementAgainstReferences(elem, doc);
 } catch {
-  throw new Error("the interesting element was not the one verified by the signature");
+  throw new Error("The interesting element was not the one verified by the signature");
+}
+
+// Use the built-in method with a an xpath expression
+try {
+  const matchingReference = sig.validateReferenceWithXPath("/xpath_to_interesting_element", doc);
+} catch {
+  throw new Error("The interesting element was not the one verified by the signature");
 }
 ```
 
@@ -194,10 +213,10 @@ var res = sig.checkSignature(xml);
 
 You might find it difficult to guess such transforms, but there are typical transforms you can try.
 
-- http://www.w3.org/TR/2001/REC-xml-c14n-20010315
-- http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments
-- http://www.w3.org/2001/10/xml-exc-c14n#
-- http://www.w3.org/2001/10/xml-exc-c14n#WithComments
+- <http://www.w3.org/TR/2001/REC-xml-c14n-20010315>
+- <http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments>
+- <http://www.w3.org/2001/10/xml-exc-c14n#>
+- <http://www.w3.org/2001/10/xml-exc-c14n#WithComments>
 
 ## API
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export interface ComputeSignatureOptionsLocation {
 /**
  * Options for the computeSignature method.
  *
- *   - `prefix` {String} Adds a prefix for the generated signature tags
+ * - `prefix` {String} Adds a prefix for the generated signature tags
  * - `attrs` {Object} A hash of attributes and values `attrName: value` to add to the signature root node
  * - `location` {{ reference: String, action: String }}
  * - `existingPrefixes` {Object} A hash of prefixes and namespaces `prefix: namespace` already in the xml
@@ -129,6 +129,10 @@ export interface Reference {
 
   // Optional. The type of the reference node.
   ancestorNamespaces?: NamespacePrefix[];
+
+  validationError?: Error;
+
+  getValidatedNode(xpathSelector?: string): Node | null;
 }
 
 /** Implement this to create a new CanonicalizationOrTransformationAlgorithm */
@@ -204,7 +208,6 @@ export interface TransformAlgorithm {
  * #### Api
  *  - {@link SignedXml#loadSignature}
  *  - {@link SignedXml#checkSignature}
- *  - {@link SignedXml#validationErrors}
  */
 
 function isErrorFirstCallback<T>(

--- a/test/document-tests.spec.ts
+++ b/test/document-tests.spec.ts
@@ -15,10 +15,9 @@ describe("Document tests", function () {
     );
 
     isDomNode.assertIsNodeLike(node);
-    const signature = new xmldom.DOMParser().parseFromString(node.toString());
     const sig = new SignedXml();
     sig.publicCert = fs.readFileSync("./test/static/feide_public.pem");
-    sig.loadSignature(signature);
+    sig.loadSignature(node);
     const result = sig.checkSignature(xml);
 
     expect(result).to.be.true;
@@ -33,13 +32,83 @@ describe("Document tests", function () {
     );
 
     isDomNode.assertIsNodeLike(node);
-    const signature = new xmldom.DOMParser().parseFromString(node.toString());
     const sig = new SignedXml();
     const feidePublicCert = fs.readFileSync("./test/static/feide_public.pem");
     sig.publicCert = feidePublicCert;
-    sig.loadSignature(signature);
+    sig.loadSignature(node);
     const result = sig.checkSignature(xml);
 
     expect(result).to.be.true;
+  });
+});
+
+describe("Validated node references tests", function () {
+  it("should return references if the document is validly signed", function () {
+    const xml = fs.readFileSync("./test/static/valid_saml.xml", "utf-8");
+    const doc = new xmldom.DOMParser().parseFromString(xml);
+    const sig = new SignedXml();
+    sig.loadSignature(sig.findSignatures(doc)[0]);
+    const validSignature = sig.checkSignature(xml);
+    expect(validSignature).to.be.true;
+
+    const ref = sig.getReferences()[0];
+    const result = ref.getValidatedNode();
+    expect(result?.toString()).to.equal(doc.toString());
+  });
+
+  it("should not return references if the document is not validly signed", function () {
+    const xml = fs.readFileSync("./test/static/invalid_signature - changed content.xml", "utf-8");
+    const doc = new xmldom.DOMParser().parseFromString(xml);
+    const sig = new SignedXml();
+    sig.loadSignature(sig.findSignatures(doc)[0]);
+    const validSignature = sig.checkSignature(xml);
+    expect(validSignature).to.be.false;
+
+    const ref = sig.getReferences()[1];
+    const result = ref.getValidatedNode();
+    expect(result).to.be.null;
+  });
+
+  it("should return `null` if the selected node isn't found", function () {
+    const xml = fs.readFileSync("./test/static/valid_saml.xml", "utf-8");
+    const doc = new xmldom.DOMParser().parseFromString(xml);
+    const sig = new SignedXml();
+    sig.loadSignature(sig.findSignatures(doc)[0]);
+    const validSignature = sig.checkSignature(xml);
+    expect(validSignature).to.be.true;
+
+    const ref = sig.getReferences()[0];
+    const result = ref.getValidatedNode("/non-existent-node");
+    expect(result).to.be.null;
+  });
+
+  it("should return the selected node if it is validly signed", function () {
+    const xml = fs.readFileSync("./test/static/valid_saml.xml", "utf-8");
+    const doc = new xmldom.DOMParser().parseFromString(xml);
+    const sig = new SignedXml();
+    sig.loadSignature(sig.findSignatures(doc)[0]);
+    const validSignature = sig.checkSignature(xml);
+    expect(validSignature).to.be.true;
+
+    const ref = sig.getReferences()[0];
+    const result = ref.getValidatedNode(
+      "//*[local-name()='Attribute' and @Name='mail']/*[local-name()='AttributeValue']/text()",
+    );
+    expect(result?.nodeValue).to.equal("henri.bergius@nemein.com");
+  });
+
+  it("should return `null` if the selected node isn't validly signed", function () {
+    const xml = fs.readFileSync("./test/static/invalid_signature - changed content.xml", "utf-8");
+    const doc = new xmldom.DOMParser().parseFromString(xml);
+    const sig = new SignedXml();
+    sig.loadSignature(sig.findSignatures(doc)[0]);
+    const validSignature = sig.checkSignature(xml);
+    expect(validSignature).to.be.false;
+
+    const ref = sig.getReferences()[0];
+    const result = ref.getValidatedNode(
+      "//*[local-name()='Attribute' and @Name='mail']/*[local-name()='AttributeValue']/text()",
+    );
+    expect(result).to.be.null;
   });
 });

--- a/test/signature-unit-tests.spec.ts
+++ b/test/signature-unit-tests.spec.ts
@@ -68,7 +68,7 @@ describe("Signature unit tests", function () {
     const checkedSignature = sig.checkSignature(xml);
     expect(checkedSignature).to.be.true;
 
-    expect(sig.references.length).to.equal(3);
+    expect(sig.getReferences().length).to.equal(3);
 
     const digests = [
       "b5GCZ2xpP5T7tbLWBTkOl4CYupQ=",
@@ -81,8 +81,8 @@ describe("Signature unit tests", function () {
     const matchedReference = sig.validateElementAgainstReferences(firstGrandchild, doc);
     expect(matchedReference).to.not.be.false;
 
-    for (let i = 0; i < sig.references.length; i++) {
-      const ref = sig.references[i];
+    for (let i = 0; i < sig.getReferences().length; i++) {
+      const ref = sig.getReferences()[i];
       const expectedUri = `#_${i}`;
       expect(
         ref.uri,


### PR DESCRIPTION
Previously, the API for checking if a reference was valid was very complex. This adds support for allow for a single method call on the container that represents the reference to determine if it passed validation. The idea is that this can clean up some code as found at `node-saml`:

```typescript
export const validateXmlSignatureForCert = (
  signature: Node,
  certPem: string,
  fullXml: string,
  currentNode: Element
): boolean => {
  const sig = new xmlCrypto.SignedXml();
  sig.keyInfoProvider = {
    file: "",
    getKeyInfo: () => "<X509Data></X509Data>",
    getKey: () => Buffer.from(certPem),
  };
  sig.loadSignature(signature);
  // We expect each signature to contain exactly one reference to the top level of the xml we
  //   are validating, so if we see anything else, reject.
  if (sig.references.length != 1) return false;
  const refUri = sig.references[0].uri;
  assertRequired(refUri, "signature reference uri not found");
  const refId = refUri[0] === "#" ? refUri.substring(1) : refUri;
  // If we can't find the reference at the top level, reject
  const idAttribute = currentNode.getAttribute("ID") ? "ID" : "Id";
  if (currentNode.getAttribute(idAttribute) != refId) return false;
  // If we find any extra referenced nodes, reject.  (xml-crypto only verifies one digest, so
  //   multiple candidate references is bad news)
  const totalReferencedNodes = xpath.selectElements(
    currentNode.ownerDocument,
    "//*[@" + idAttribute + "='" + refId + "']"
  );

  if (totalReferencedNodes.length > 1) {
    return false;
  }
  fullXml = normalizeNewlines(fullXml);
  return sig.checkSignature(fullXml);
};
```

Which code follows the recommendation in the README:

```javascript
// Roll your own
var elem = xpath.select("/xpath_to_interesting_element", doc);
var uri = sig.references[0].uri; // might not be 0 - depending on the document you verify
var id = uri[0] === "#" ? uri.substring(1) : uri;
if (elem.getAttribute("ID") != id && elem.getAttribute("Id") != id && elem.getAttribute("id") != id)
  throw new Error("the interesting element was not the one verified by the signature");

// Use the built-in method
let elem = xpath.select("/xpath_to_interesting_element", doc);
try {
  const matchingReference = sig.validateElementAgainstReferences(elem, doc);
} catch {
  throw new Error("the interesting element was not the one verified by the signature");
}
```

Since we already know about the `id` internally, this shouldn't have to be re-implemented by a consumer.