### PR TITLE
Make references accessible only via get/set

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ In order to protect from some attacks we must check the content we want to use i
 ```javascript
 // Roll your own
 var elem = xpath.select("/xpath_to_interesting_element", doc);
-var uri = sig.references[0].uri; // might not be 0 - depending on the document you verify
+var uri = sig.getReferences()[0].uri; // might not be 0 - depending on the document you verify
 var id = uri[0] === "#" ? uri.substring(1) : uri;
 if (elem.getAttribute("ID") != id && elem.getAttribute("Id") != id && elem.getAttribute("id") != id)
   throw new Error("the interesting element was not the one verified by the signature");

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -70,7 +70,7 @@ export class SignedXml {
    * Contains the references that were signed.
    * @see {@link Reference}
    */
-  references: Reference[] = [];
+  private references: Reference[] = [];
 
   /**
    * Contains validation errors (if any) after {@link checkSignature} method is called
@@ -253,9 +253,9 @@ export class SignedXml {
 
     const doc = new xmldom.DOMParser().parseFromString(xml);
 
-    if (!this.validateReferences(doc)) {
+    if (!this.getReferences().every((ref) => this.validateReference(ref, doc))) {
       if (callback) {
-        callback(new Error("Could not validate references"));
+        callback(new Error("Could not validate all references"));
         return;
       }
 
@@ -372,7 +372,7 @@ export class SignedXml {
   }
 
   validateElementAgainstReferences(elem: Element, doc: Document): Reference {
-    for (const ref of this.references) {
+    for (const ref of this.getReferences()) {
       const uri = ref.uri?.[0] === "#" ? ref.uri.substring(1) : ref.uri;
       let targetElem: xpath.SelectSingleReturnType;
 
@@ -647,6 +647,10 @@ export class SignedXml {
     });
   }
 
+  getReferences(): Reference[] {
+    return this.references;
+  }
+
   /**
    * Compute the signature of the given XML (using the already defined settings).
    *
@@ -879,7 +883,7 @@ export class SignedXml {
     prefix = prefix || "";
     prefix = prefix ? `${prefix}:` : prefix;
 
-    for (const ref of this.references) {
+    for (const ref of this.getReferences()) {
       const nodes = xpath.selectWithResolver(ref.xpath ?? "", doc, this.namespaceResolver);
 
       if (!utils.isArrayHasLength(nodes)) {

--- a/test/signature-unit-tests.spec.ts
+++ b/test/signature-unit-tests.spec.ts
@@ -68,7 +68,7 @@ describe("Signature unit tests", function () {
     const checkedSignature = sig.checkSignature(xml);
     expect(checkedSignature).to.be.true;
 
-    expect(sig.references.length).to.equal(3);
+    expect(sig.getReferences().length).to.equal(3);
 
     const digests = [
       "b5GCZ2xpP5T7tbLWBTkOl4CYupQ=",
@@ -81,8 +81,8 @@ describe("Signature unit tests", function () {
     const matchedReference = sig.validateElementAgainstReferences(firstGrandchild, doc);
     expect(matchedReference).to.not.be.false;
 
-    for (let i = 0; i < sig.references.length; i++) {
-      const ref = sig.references[i];
+    for (let i = 0; i < sig.getReferences().length; i++) {
+      const ref = sig.getReferences()[i];
       const expectedUri = `#_${i}`;
       expect(
         ref.uri,


### PR DESCRIPTION
The `references` array is a little sensitive to what is in it, we don't want people mutating it without the accessors. 