### PR TITLE
Move validation messages to each reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,8 @@ var signature = select(
 var sig = new SignedXml({ publicCert: fs.readFileSync("client_public.pem") });
 sig.loadSignature(signature);
 var res = sig.checkSignature(xml);
-if (!res) console.log(sig.validationErrors);
+if (!res) console.log("signature validation failed");
 ```
-
-If the verification process fails `sig.validationErrors` will contain the errors.
 
 In order to protect from some attacks we must check the content we want to use is the one that has been signed:
 
@@ -247,8 +245,7 @@ To verify xml documents:
 
 - `loadSignature(signatureXml)` - loads the signature where:
   - `signatureXml` - a string or node object (like an [xmldom](https://github.com/xmldom/xmldom) node) containing the xml representation of the signature
-- `checkSignature(xml)` - validates the given xml document and returns true if the validation was successful, `sig.validationErrors` will have the validation errors if any, where:
-  - `xml` - a string containing a xml document
+- `checkSignature(xml)` - validates the given xml document and returns `true` if the validation was successful
 
 ## Customizing Algorithms
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,11 @@ var signature = select(
 )[0];
 var sig = new SignedXml({ publicCert: fs.readFileSync("client_public.pem") });
 sig.loadSignature(signature);
-var res = sig.checkSignature(xml);
-if (!res) console.log("signature validation failed");
+try {
+  var res = sig.checkSignature(xml);
+} catch (ex) {
+  console.log(ex);
+}
 ```
 
 In order to protect from some attacks we must check the content we want to use is the one that has been signed:

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -265,9 +265,15 @@ export class SignedXml {
     if (callback) {
       signer.verifySignature(signedInfoCanon, key, this.signatureValue, callback);
     } else {
-      const res = signer.verifySignature(signedInfoCanon, key, this.signatureValue);
+      const verified = signer.verifySignature(signedInfoCanon, key, this.signatureValue);
 
-      return res;
+      if (verified === false) {
+        throw new Error(
+          "invalid signature: the signature value ${this.signatureValue} is incorrect",
+        );
+      }
+
+      return true;
     }
   }
 

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -73,11 +73,6 @@ export class SignedXml {
   private references: Reference[] = [];
 
   /**
-   * Contains validation errors (if any) after {@link checkSignature} method is called
-   */
-  validationErrors: string[] = [];
-
-  /**
    *  To add a new transformation algorithm create a new class that implements the {@link TransformationAlgorithm} interface, and register it here. More info: {@link https://github.com/node-saml/xml-crypto#customizing-algorithms|Customizing Algorithms}
    */
   CanonicalizationAlgorithms: Record<
@@ -248,7 +243,6 @@ export class SignedXml {
       throw new Error("Last parameter must be a callback function");
     }
 
-    this.validationErrors = [];
     this.signedXml = xml;
 
     const doc = new xmldom.DOMParser().parseFromString(xml);
@@ -272,11 +266,6 @@ export class SignedXml {
       signer.verifySignature(signedInfoCanon, key, this.signatureValue, callback);
     } else {
       const res = signer.verifySignature(signedInfoCanon, key, this.signatureValue);
-      if (res === false) {
-        this.validationErrors.push(
-          `invalid signature: the signature value ${this.signatureValue} is incorrect`,
-        );
-      }
 
       return res;
     }
@@ -438,7 +427,7 @@ export class SignedXml {
       const validationError = new Error(
         `invalid signature: the signature references an element with uri ${ref.uri} but could not find such element in the xml`,
       );
-      this.validationErrors.push(validationError.message);
+      ref.validationError = validationError;
       return false;
     }
 
@@ -450,7 +439,7 @@ export class SignedXml {
       const validationError = new Error(
         `invalid signature: for uri ${ref.uri} calculated digest is ${digest} but the xml to validate supplies digest ${ref.digestValue}`,
       );
-      this.validationErrors.push(validationError.message);
+      ref.validationError = validationError;
 
       return false;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,8 @@ export interface Reference {
 
   // Optional. The type of the reference node.
   ancestorNamespaces?: NamespacePrefix[];
+
+  validationError?: Error;
 }
 
 /** Implement this to create a new CanonicalizationOrTransformationAlgorithm */
@@ -204,7 +206,6 @@ export interface TransformAlgorithm {
  * #### Api
  *  - {@link SignedXml#loadSignature}
  *  - {@link SignedXml#checkSignature}
- *  - {@link SignedXml#validationErrors}
  */
 
 function isErrorFirstCallback<T>(

--- a/test/hmac-tests.spec.ts
+++ b/test/hmac-tests.spec.ts
@@ -37,9 +37,8 @@ describe("HMAC tests", function () {
     sig.enableHMAC();
     sig.publicCert = fs.readFileSync("./test/static/hmac-foobar.key");
     sig.loadSignature(signature);
-    const result = sig.checkSignature(xml);
 
-    expect(result).to.be.false;
+    expect(() => sig.checkSignature(xml)).to.throw(/^invalid signature/);
   });
 
   it("test create and validate HMAC signature", function () {

--- a/test/saml-response-tests.spec.ts
+++ b/test/saml-response-tests.spec.ts
@@ -89,8 +89,7 @@ describe("SAML response tests", function () {
     const sig = new SignedXml();
     sig.publicCert = fs.readFileSync("./test/static/feide_public.pem");
     sig.loadSignature(signature);
-    const result = sig.checkSignature(xml);
     // This doesn't matter, just want to make sure that we don't fail due to unknown algorithm
-    expect(result).to.be.false;
+    expect(() => sig.checkSignature(xml)).to.throw(/^invalid signature/);
   });
 });


### PR DESCRIPTION
Validation errors were class-wide making it unnecessarily difficult to match an error with the reference that caused it. This PR moves those errors to the `reference` on which they occurred.

 Additionally, the validation error for a `checkSignature()` was changed to throw instead of adding to a global `validationErrors` object.