### PR TITLE
Remove default canonicalization algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ by default the following algorithms are used:
 
 _Canonicalization/Transformation Algorithm:_ Exclusive Canonicalization <http://www.w3.org/2001/10/xml-exc-c14n#>
 
-_Hashing Algorithm:_ SHA1 digest <http://www.w3.org/2000/09/xmldsig#sha1>
+_Hashing/Digest Algorithm:_ SHA1 digest <http://www.w3.org/2000/09/xmldsig#sha1>
 
 _Signature Algorithm:_ RSA-SHA1 <http://www.w3.org/2000/09/xmldsig#rsa-sha1>
 
@@ -244,7 +244,7 @@ The `SignedXml` constructor provides an abstraction for sign and verify xml docu
 - `privateKey` - string or Buffer - default `null` - the private key to use for signing
 - `publicCert` - string or Buffer - default `null` - the public certificate to use for verifying
 - `signatureAlgorithm` - string - default `http://www.w3.org/2000/09/xmldsig#rsa-sha1` - the signature algorithm to use
-- `canonicalizationAlgorithm` - string - default `http://www.w3.org/TR/2001/REC-xml-c14n-20010315` - the canonicalization algorithm to use
+- `canonicalizationAlgorithm` - string - default `undefined` - the canonicalization algorithm to use
 - `inclusiveNamespacesPrefixList` - string - default `null` - a list of namespace prefixes to include during canonicalization
 - `implicitTransforms` - string[] - default `[]` - a list of implicit transforms to use during verification
 - `keyInfoAttributes` - object - default `{}` - a hash of attributes and values `attrName: value` to add to the KeyInfo node
@@ -313,7 +313,7 @@ function MyDigest() {
 }
 ```
 
-A custom signing algorithm. The default is RSA-SHA1.
+A custom signing algorithm.
 
 ```javascript
 function MySignatureAlgorithm() {
@@ -328,7 +328,7 @@ function MySignatureAlgorithm() {
 }
 ```
 
-Custom transformation algorithm. The default is exclusive canonicalization.
+Custom transformation algorithm.
 
 ```javascript
 function MyTransformation() {

--- a/src/c14n-canonicalization.ts
+++ b/src/c14n-canonicalization.ts
@@ -8,7 +8,11 @@ import * as utils from "./utils";
 import * as isDomNode from "@xmldom/is-dom-node";
 
 export class C14nCanonicalization implements CanonicalizationOrTransformationAlgorithm {
-  includeComments = false;
+  protected includeComments = false;
+
+  constructor() {
+    this.includeComments = false;
+  }
 
   attrCompare(a, b) {
     if (!a.namespaceURI && b.namespaceURI) {

--- a/src/enveloped-signature.ts
+++ b/src/enveloped-signature.ts
@@ -8,7 +8,12 @@ import type {
 } from "./types";
 
 export class EnvelopedSignature implements CanonicalizationOrTransformationAlgorithm {
-  includeComments = false;
+  protected includeComments = false;
+
+  constructor() {
+    this.includeComments = false;
+  }
+
   process(node: Node, options: CanonicalizationOrTransformationAlgorithmProcessOptions): Node {
     if (null == options.signatureNode) {
       const signature = xpath.select1(

--- a/src/exclusive-canonicalization.ts
+++ b/src/exclusive-canonicalization.ts
@@ -18,7 +18,11 @@ function isPrefixInScope(prefixesInScope, prefix, namespaceURI) {
 }
 
 export class ExclusiveCanonicalization implements CanonicalizationOrTransformationAlgorithm {
-  includeComments = false;
+  protected includeComments = false;
+
+  constructor() {
+    this.includeComments = false;
+  }
 
   attrCompare(a, b) {
     if (!a.namespaceURI && b.namespaceURI) {

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -139,7 +139,7 @@ export class SignedXml {
     this.privateKey = privateKey;
     this.publicCert = publicCert;
     this.signatureAlgorithm = signatureAlgorithm ?? this.signatureAlgorithm;
-    this.canonicalizationAlgorithm = canonicalizationAlgorithm ;
+    this.canonicalizationAlgorithm = canonicalizationAlgorithm;
     if (typeof inclusiveNamespacesPrefixList === "string") {
       this.inclusiveNamespacesPrefixList = inclusiveNamespacesPrefixList.split(" ");
     } else if (utils.isArrayHasLength(inclusiveNamespacesPrefixList)) {
@@ -314,7 +314,7 @@ export class SignedXml {
     const c14nOptions = {
       ancestorNamespaces: ancestorNamespaces,
     };
-   
+
     return this.getCanonXml([this.canonicalizationAlgorithm], signedInfo[0], c14nOptions);
   }
 
@@ -1030,7 +1030,9 @@ export class SignedXml {
    */
   private createSignedInfo(doc, prefix) {
     if (typeof this.canonicalizationAlgorithm !== "string") {
-      throw new Error("Missing canonicalizationAlgorithm when trying to create signed info for XML");
+      throw new Error(
+        "Missing canonicalizationAlgorithm when trying to create signed info for XML",
+      );
     }
     const transform = this.findCanonicalizationAlgorithm(this.canonicalizationAlgorithm);
     const algo = this.findSignatureAlgorithm(this.signatureAlgorithm);

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -41,8 +41,7 @@ export class SignedXml {
   /**
    * Rules used to convert an XML document into its canonical form.
    */
-  canonicalizationAlgorithm: CanonicalizationAlgorithmType =
-    "http://www.w3.org/2001/10/xml-exc-c14n#";
+  canonicalizationAlgorithm?: CanonicalizationAlgorithmType = undefined;
   /**
    * It specifies a list of namespace prefixes that should be considered "inclusive" during the canonicalization process.
    */
@@ -140,7 +139,7 @@ export class SignedXml {
     this.privateKey = privateKey;
     this.publicCert = publicCert;
     this.signatureAlgorithm = signatureAlgorithm ?? this.signatureAlgorithm;
-    this.canonicalizationAlgorithm = canonicalizationAlgorithm ?? this.canonicalizationAlgorithm;
+    this.canonicalizationAlgorithm = canonicalizationAlgorithm ;
     if (typeof inclusiveNamespacesPrefixList === "string") {
       this.inclusiveNamespacesPrefixList = inclusiveNamespacesPrefixList.split(" ");
     } else if (utils.isArrayHasLength(inclusiveNamespacesPrefixList)) {
@@ -286,6 +285,9 @@ export class SignedXml {
     if (this.signatureNode == null) {
       throw new Error("No signature found.");
     }
+    if (typeof this.canonicalizationAlgorithm !== "string") {
+      throw new Error("Missing canonicalizationAlgorithm when trying to get signed info for XML");
+    }
 
     const signedInfo = utils.findChildren(this.signatureNode, "SignedInfo");
     if (signedInfo.length === 0) {
@@ -312,6 +314,7 @@ export class SignedXml {
     const c14nOptions = {
       ancestorNamespaces: ancestorNamespaces,
     };
+   
     return this.getCanonXml([this.canonicalizationAlgorithm], signedInfo[0], c14nOptions);
   }
 
@@ -354,12 +357,14 @@ export class SignedXml {
   }
 
   private findCanonicalizationAlgorithm(name: CanonicalizationOrTransformAlgorithmType) {
-    const algo = this.CanonicalizationAlgorithms[name];
-    if (algo) {
-      return new algo();
-    } else {
-      throw new Error(`canonicalization algorithm '${name}' is not supported`);
+    if (name != null) {
+      const algo = this.CanonicalizationAlgorithms[name];
+      if (algo) {
+        return new algo();
+      }
     }
+
+    throw new Error(`canonicalization algorithm '${name}' is not supported`);
   }
 
   private findHashAlgorithm(name: HashAlgorithmType) {
@@ -1024,6 +1029,9 @@ export class SignedXml {
    *
    */
   private createSignedInfo(doc, prefix) {
+    if (typeof this.canonicalizationAlgorithm !== "string") {
+      throw new Error("Missing canonicalizationAlgorithm when trying to create signed info for XML");
+    }
     const transform = this.findCanonicalizationAlgorithm(this.canonicalizationAlgorithm);
     const algo = this.findSignatureAlgorithm(this.signatureAlgorithm);
     let currentPrefix;

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,8 +143,6 @@ export interface CanonicalizationOrTransformationAlgorithm {
   ): Node | string;
 
   getAlgorithmName(): CanonicalizationOrTransformAlgorithmType;
-
-  includeComments: boolean;
 }
 
 /** Implement this to create a new HashAlgorithm */

--- a/test/hmac-tests.spec.ts
+++ b/test/hmac-tests.spec.ts
@@ -48,6 +48,7 @@ describe("HMAC tests", function () {
     sig.privateKey = fs.readFileSync("./test/static/hmac.key");
     sig.signatureAlgorithm = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
     sig.addReference({ xpath: "//*[local-name(.)='book']" });
+    sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml);
 
     const doc = new xmldom.DOMParser().parseFromString(sig.getSignedXml());

--- a/test/key-info-tests.spec.ts
+++ b/test/key-info-tests.spec.ts
@@ -11,6 +11,7 @@ describe("KeyInfo tests", function () {
     const sig = new SignedXml();
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
     sig.publicCert = fs.readFileSync("./test/static/client_public.pem");
+    sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
     const doc = new xmldom.DOMParser().parseFromString(signedXml);
@@ -28,6 +29,7 @@ describe("KeyInfo tests", function () {
     sig.signatureAlgorithm = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
     sig.enableHMAC();
     sig.addReference({ xpath: "//*[local-name(.)='book']" });
+    sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml);
 
     const doc = new xmldom.DOMParser().parseFromString(sig.getSignedXml());

--- a/test/signature-integration-tests.spec.ts
+++ b/test/signature-integration-tests.spec.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 import * as isDomNode from "@xmldom/is-dom-node";
 
 describe("Signature integration tests", function () {
-  function verifySignature(xml, expected, xpath) {
+  function verifySignature(xml, expected, xpath, canonicalizationAlgorithm) {
     const sig = new SignedXml();
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
 
@@ -14,6 +14,7 @@ describe("Signature integration tests", function () {
       sig.addReference({ xpath: n });
     });
 
+    sig.canonicalizationAlgorithm = canonicalizationAlgorithm;
     sig.computeSignature(xml);
     const signed = sig.getSignedXml();
 
@@ -28,7 +29,7 @@ describe("Signature integration tests", function () {
       "//*[local-name(.)='x']",
       "//*[local-name(.)='y']",
       "//*[local-name(.)='w']",
-    ]);
+    ],"http://www.w3.org/2001/10/xml-exc-c14n#");
   });
 
   it("verify signature of complex element", function () {
@@ -45,7 +46,7 @@ describe("Signature integration tests", function () {
 
     verifySignature(xml, "./test/static/integration/expectedVerifyComplex.xml", [
       "//*[local-name(.)='book']",
-    ]);
+    ],"http://www.w3.org/2001/10/xml-exc-c14n#");
   });
 
   it("empty URI reference should consider the whole document", function () {
@@ -168,6 +169,7 @@ describe("Signature integration tests", function () {
     const sig = new SignedXml();
     sig.addReference({ xpath: "//*[local-name(.)='book']" });
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
+    sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml);
 
     const signed = sig.getSignedXml();

--- a/test/signature-integration-tests.spec.ts
+++ b/test/signature-integration-tests.spec.ts
@@ -25,11 +25,12 @@ describe("Signature integration tests", function () {
   it("verify signature", function () {
     const xml =
       '<root><x xmlns="ns"></x><y z_attr="value" a_attr1="foo"></y><z><ns:w ns:attr="value" xmlns:ns="myns"></ns:w></z></root>';
-    verifySignature(xml, "./test/static/integration/expectedVerify.xml", [
-      "//*[local-name(.)='x']",
-      "//*[local-name(.)='y']",
-      "//*[local-name(.)='w']",
-    ],"http://www.w3.org/2001/10/xml-exc-c14n#");
+    verifySignature(
+      xml,
+      "./test/static/integration/expectedVerify.xml",
+      ["//*[local-name(.)='x']", "//*[local-name(.)='y']", "//*[local-name(.)='w']"],
+      "http://www.w3.org/2001/10/xml-exc-c14n#",
+    );
   });
 
   it("verify signature of complex element", function () {
@@ -44,9 +45,12 @@ describe("Signature integration tests", function () {
       "</book>" +
       "</library>";
 
-    verifySignature(xml, "./test/static/integration/expectedVerifyComplex.xml", [
-      "//*[local-name(.)='book']",
-    ],"http://www.w3.org/2001/10/xml-exc-c14n#");
+    verifySignature(
+      xml,
+      "./test/static/integration/expectedVerifyComplex.xml",
+      ["//*[local-name(.)='book']"],
+      "http://www.w3.org/2001/10/xml-exc-c14n#",
+    );
   });
 
   it("empty URI reference should consider the whole document", function () {


### PR DESCRIPTION
This removes the default canonicalization algorithm forcing the consumer to choose the one that they want. This is an attempt to address #376.

Side note: We do not support all the "required" algorithms. See: https://www.w3.org/TR/xmldsig-core1/#:~:text=4.1%20DSA%5D-,canonicalization,-Required