### PR TITLE
Remove default for digest algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ This will enable HMAC and disable digital signature algorithms. Due to key
 confusion issues, it is risky to have both HMAC-based and public key digital
 signature algorithms enabled at same time.
 
-by default the following algorithms are used:
+By default the following algorithms are used:
 
 _Canonicalization/Transformation Algorithm:_ Exclusive Canonicalization <http://www.w3.org/2001/10/xml-exc-c14n#>
 
-_Hashing/Digest Algorithm:_ SHA1 digest <http://www.w3.org/2000/09/xmldsig#sha1>
+_Hashing/Digest Algorithm:_ Must be specified by the user
 
 _Signature Algorithm:_ RSA-SHA1 <http://www.w3.org/2000/09/xmldsig#rsa-sha1>
 

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -637,7 +637,7 @@ export class SignedXml {
    *
    * @param xpath The XPath expression to select the XML nodes to be referenced.
    * @param transforms An array of transform algorithms to be applied to the selected nodes. Defaults to ["http://www.w3.org/2001/10/xml-exc-c14n#"].
-   * @param digestAlgorithm The digest algorithm to use for computing the digest value. Defaults to "http://www.w3.org/2000/09/xmldsig#sha1".
+   * @param digestAlgorithm The digest algorithm to use for computing the digest value.
    * @param uri The URI identifier for the reference. If empty, an empty URI will be used.
    * @param digestValue The expected digest value for the reference.
    * @param inclusiveNamespacesPrefixList The prefix list for inclusive namespace canonicalization.
@@ -646,12 +646,16 @@ export class SignedXml {
   addReference({
     xpath,
     transforms = ["http://www.w3.org/2001/10/xml-exc-c14n#"],
-    digestAlgorithm = "http://www.w3.org/2000/09/xmldsig#sha1",
+    digestAlgorithm,
     uri = "",
     digestValue,
     inclusiveNamespacesPrefixList = [],
     isEmptyUri = false,
   }: Partial<Reference> & Pick<Reference, "xpath">): void {
+    if (digestAlgorithm == null) {
+      throw new Error("digestAlgorithm is required");
+    }
+
     this.references.push({
       xpath,
       transforms,

--- a/test/hmac-tests.spec.ts
+++ b/test/hmac-tests.spec.ts
@@ -47,7 +47,10 @@ describe("HMAC tests", function () {
     sig.enableHMAC();
     sig.privateKey = fs.readFileSync("./test/static/hmac.key");
     sig.signatureAlgorithm = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
-    sig.addReference({ xpath: "//*[local-name(.)='book']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='book']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml);
 

--- a/test/key-info-tests.spec.ts
+++ b/test/key-info-tests.spec.ts
@@ -28,7 +28,10 @@ describe("KeyInfo tests", function () {
     sig.publicCert = fs.readFileSync("./test/static/hmac.key");
     sig.signatureAlgorithm = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
     sig.enableHMAC();
-    sig.addReference({ xpath: "//*[local-name(.)='book']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='book']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml);
 

--- a/test/signature-integration-tests.spec.ts
+++ b/test/signature-integration-tests.spec.ts
@@ -11,7 +11,7 @@ describe("Signature integration tests", function () {
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
 
     xpath.map(function (n) {
-      sig.addReference({ xpath: n });
+      sig.addReference({ xpath: n, digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1" });
     });
 
     sig.canonicalizationAlgorithm = canonicalizationAlgorithm;
@@ -171,7 +171,10 @@ describe("Signature integration tests", function () {
     const xml = "<library>" + "<book>" + "<name>Harry Potter</name>" + "</book>" + "</library>";
 
     const sig = new SignedXml();
-    sig.addReference({ xpath: "//*[local-name(.)='book']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='book']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml);

--- a/test/signature-unit-tests.spec.ts
+++ b/test/signature-unit-tests.spec.ts
@@ -22,9 +22,18 @@ describe("Signature unit tests", function () {
       const sig = new SignedXml({ idMode: mode });
       sig.privateKey = fs.readFileSync("./test/static/client.pem");
 
-      sig.addReference({ xpath: "//*[local-name(.)='x']" });
-      sig.addReference({ xpath: "//*[local-name(.)='y']" });
-      sig.addReference({ xpath: "//*[local-name(.)='w']" });
+      sig.addReference({
+        xpath: "//*[local-name(.)='x']",
+        digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+      });
+      sig.addReference({
+        xpath: "//*[local-name(.)='y']",
+        digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+      });
+      sig.addReference({
+        xpath: "//*[local-name(.)='w']",
+        digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+      });
 
       sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
       sig.computeSignature(xml);
@@ -57,7 +66,10 @@ describe("Signature unit tests", function () {
 
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
 
-    sig.addReference({ xpath: "//*[@wsu:Id]" });
+    sig.addReference({
+      xpath: "//*[@wsu:Id]",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
 
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml, {
@@ -78,7 +90,10 @@ describe("Signature unit tests", function () {
       const xml = `<x xmlns:wsu='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd' ${prefix}Id='_1'></x>`;
       const sig = new SignedXml({ idMode });
       sig.privateKey = fs.readFileSync("./test/static/client.pem");
-      sig.addReference({ xpath: "//*[local-name(.)='x']" });
+      sig.addReference({
+        xpath: "//*[local-name(.)='x']",
+        digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+      });
       sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
       sig.computeSignature(xml);
       const signedXml = sig.getOriginalXmlWithIds();
@@ -108,7 +123,10 @@ describe("Signature unit tests", function () {
 
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
 
-    sig.addReference({ xpath: "//*[local-name(.)='name']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='name']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
 
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml, {
@@ -140,7 +158,10 @@ describe("Signature unit tests", function () {
     const sig = new SignedXml();
 
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
-    sig.addReference({ xpath: "//*[local-name(.)='name']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='name']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml);
 
@@ -159,7 +180,10 @@ describe("Signature unit tests", function () {
     const sig = new SignedXml();
 
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
-    sig.addReference({ xpath: "//*[local-name(.)='repository']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='repository']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
 
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml, {
@@ -186,7 +210,10 @@ describe("Signature unit tests", function () {
     const sig = new SignedXml();
 
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
-    sig.addReference({ xpath: "//*[local-name(.)='repository']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='repository']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
 
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml, {
@@ -212,7 +239,10 @@ describe("Signature unit tests", function () {
     const sig = new SignedXml();
 
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
-    sig.addReference({ xpath: "//*[local-name(.)='repository']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='repository']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
 
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml, {
@@ -239,7 +269,10 @@ describe("Signature unit tests", function () {
     const sig = new SignedXml();
 
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
-    sig.addReference({ xpath: "//*[local-name(.)='repository']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='repository']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
 
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml, {
@@ -590,9 +623,18 @@ describe("Signature unit tests", function () {
     const sig = new SignedXml();
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
 
-    sig.addReference({ xpath: "//*[local-name(.)='x']" });
-    sig.addReference({ xpath: "//*[local-name(.)='y']" });
-    sig.addReference({ xpath: "//*[local-name(.)='w']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='x']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
+    sig.addReference({
+      xpath: "//*[local-name(.)='y']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
+    sig.addReference({
+      xpath: "//*[local-name(.)='w']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
 
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml);
@@ -658,9 +700,18 @@ describe("Signature unit tests", function () {
     sig.signatureAlgorithm = "http://dummySignatureAlgorithmAsync";
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
 
-    sig.addReference({ xpath: "//*[local-name(.)='x']" });
-    sig.addReference({ xpath: "//*[local-name(.)='y']" });
-    sig.addReference({ xpath: "//*[local-name(.)='w']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='x']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
+    sig.addReference({
+      xpath: "//*[local-name(.)='y']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
+    sig.addReference({
+      xpath: "//*[local-name(.)='w']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
 
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.computeSignature(xml, function () {
@@ -918,7 +969,10 @@ describe("Signature unit tests", function () {
     const sig = new SignedXml();
 
     sig.privateKey = fs.readFileSync("./test/static/client.pem");
-    sig.addReference({ xpath: "//*[local-name(.)='repository']" });
+    sig.addReference({
+      xpath: "//*[local-name(.)='repository']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+    });
 
     try {
       sig.computeSignature(xml, {


### PR DESCRIPTION
This removes the default digest algorithm forcing the consumer to choose the one that they want. This is an attempt to address https://github.com/node-saml/xml-crypto/issues/376.