### PR TITLE
Remove the default for `getKeyInfoContent` forcing a consumer to choose

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ When verifying a xml document you can pass the following options to the `SignedX
 - `publicCert` - **[optional]** your certificate as a string, a string of multiple certs in PEM format, or a Buffer
 - `privateKey` - **[optional]** your private key as a string or a Buffer - used for verifying symmetrical signatures (HMAC)
 
-The certificate that will be used to check the signature will first be determined by calling `.getCertFromKeyInfo()`, which function you can customize as you see fit. If that returns `null`, then `publicCert` is used. If that is `null`, then `privateKey` is used (for symmetrical signing applications). If you do not want to trust any embedded `<KeyInfo />` node, preferring to validate the signature using a provided `publicCert`, you can set `getCertFromKeyInfo` to return `null`.
+The certificate that will be used to check the signature will first be determined by calling `this.getCertFromKeyInfo()`, which function you can customize as you see fit. If that returns `null`, then `publicCert` is used. If that is `null`, then `privateKey` is used (for symmetrical signing applications).
 
 Example:
 
@@ -246,7 +246,7 @@ The `SignedXml` constructor provides an abstraction for sign and verify xml docu
 - `inclusiveNamespacesPrefixList` - string - default `null` - a list of namespace prefixes to include during canonicalization
 - `implicitTransforms` - string[] - default `[]` - a list of implicit transforms to use during verification
 - `keyInfoAttributes` - object - default `{}` - a hash of attributes and values `attrName: value` to add to the KeyInfo node
-- `getKeyInfoContent` - function - default `SignedXml.geTKeyInfoContent` - a function that returns the content of the KeyInfo node
+- `getKeyInfoContent` - function - default `noop` - a function that returns the content of the KeyInfo node
 - `getCertFromKeyInfo` - function - default `SignedXml.getCertFromKeyInfo` - a function that returns the certificate from the `<KeyInfo />` node
 
 #### API
@@ -290,8 +290,8 @@ var SignedXml = require("xml-crypto").SignedXml,
 Now define the extension point you want to implement. You can choose one or more.
 
 To determine the inclusion and contents of a `<KeyInfo />` element, the function
-`getKeyInfoContent()` is called. There is a default implementation of this. If you wish to change
-this implementation, provide your own function assigned to the property `.getKeyInfoContent`. If
+`this.getKeyInfoContent()` is called. There is a default implementation of this. If you wish to change
+this implementation, provide your own function assigned to the property `this.getKeyInfoContent`. If you prefer to use the default implementation, assign `SignedXml.getKeyInfoContent` to `this.getKeyInfoContent` If
 there are no attributes and no contents to the `<KeyInfo />` element, it won't be included in the
 generated XML.
 

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -111,6 +111,8 @@ export class SignedXml {
     ds: "http://www.w3.org/2000/09/xmldsig#",
   };
 
+  static noop = () => null;
+
   /**
    * The SignedXml constructor provides an abstraction for sign and verify xml documents. The object is constructed using
    * @param options {@link SignedXmlOptions}
@@ -147,7 +149,7 @@ export class SignedXml {
     }
     this.implicitTransforms = implicitTransforms ?? this.implicitTransforms;
     this.keyInfoAttributes = keyInfoAttributes ?? this.keyInfoAttributes;
-    this.getKeyInfoContent = getKeyInfoContent ?? this.getKeyInfoContent;
+    this.getKeyInfoContent = getKeyInfoContent ?? SignedXml.noop;
     this.getCertFromKeyInfo = getCertFromKeyInfo ?? this.getCertFromKeyInfo;
     this.CanonicalizationAlgorithms;
     this.HashAlgorithms;
@@ -163,7 +165,7 @@ export class SignedXml {
     this.SignatureAlgorithms = {
       "http://www.w3.org/2000/09/xmldsig#hmac-sha1": signatureAlgorithms.HmacSha1,
     };
-    this.getKeyInfoContent = () => null;
+    this.getKeyInfoContent = SignedXml.noop;
   }
 
   /**

--- a/test/key-info-tests.spec.ts
+++ b/test/key-info-tests.spec.ts
@@ -13,6 +13,7 @@ describe("KeyInfo tests", function () {
     sig.publicCert = fs.readFileSync("./test/static/client_public.pem");
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.signatureAlgorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+    sig.getKeyInfoContent = SignedXml.getKeyInfoContent;
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
     const doc = new xmldom.DOMParser().parseFromString(signedXml);

--- a/test/signature-unit-tests.spec.ts
+++ b/test/signature-unit-tests.spec.ts
@@ -534,6 +534,7 @@ describe("Signature unit tests", function () {
     sig.signatureAlgorithm = "http://dummySignatureAlgorithm";
     sig.canonicalizationAlgorithm = "http://DummyCanonicalization";
     sig.privateKey = "";
+    sig.getKeyInfoContent = SignedXml.getKeyInfoContent;
 
     sig.addReference({
       xpath: "//*[local-name(.)='x']",
@@ -1236,6 +1237,7 @@ describe("Signature unit tests", function () {
     sig.publicCert = pemBuffer;
     sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
     sig.signatureAlgorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+    sig.getKeyInfoContent = SignedXml.getKeyInfoContent;
     sig.computeSignature(xml);
     const signedXml = sig.getSignedXml();
 


### PR DESCRIPTION
Per the discussion [here](https://github.com/node-saml/xml-crypto/discussions/399#discussioncomment-7264750), remove the default for `getKeyInfoContent`. This will force the consumer to make a decision here. The default implementation is still available.