### PR TITLE
Exports C14nCanonicalization, ExclusiveCanonicalization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export { SignedXml } from "./signed-xml";
+export { C14nCanonicalization, C14nCanonicalizationWithComments } from "./c14n-canonicalization";
+export { ExclusiveCanonicalization, ExclusiveCanonicalizationWithComments } from "./exclusive-canonicalization";
 export * from "./utils";
 export * from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 export { SignedXml } from "./signed-xml";
 export { C14nCanonicalization, C14nCanonicalizationWithComments } from "./c14n-canonicalization";
-export { ExclusiveCanonicalization, ExclusiveCanonicalizationWithComments } from "./exclusive-canonicalization";
+export {
+  ExclusiveCanonicalization,
+  ExclusiveCanonicalizationWithComments,
+} from "./exclusive-canonicalization";
 export * from "./utils";
 export * from "./types";


### PR DESCRIPTION
After #325 this functionality was lost

Trying same as #335

>This allow us to do
>```ts
>const C14nCanonicalization = require('xml-crypto').C14nCanonicalization 
>const ExclusiveCanonicalization= require('xml-crypto').ExclusiveCanonicalization
>
>// Use Example 
>const DOMParser = require("@xmldom/xmldom").DOMParser
>let xml_string = '<root><child>123</child></root>'
>let documentElement= (new DOMParser()).parseFromString(xml_string).documentElement
>
>// C14nCanonicalization
>console.log( (new C14nCanonicalization()).process(documentElement, {}).toString() )
>// ExclusiveCanonicalization
>console.log( (new ExclusiveCanonicalization()).process(documentElement, {}).toString() )
>```