### PR TITLE
Add .signedReferences API

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -288,6 +288,7 @@ function SignedXml(idMode, options) {
   this.idAttributes = ["Id", "ID", "id"];
   if (this.options.idAttribute) this.idAttributes.splice(0, 0, this.options.idAttribute);
   this.implicitTransforms = this.options.implicitTransforms || [];
+  this.signedReferences = [];
 }
 
 SignedXml.CanonicalizationAlgorithms = {
@@ -364,6 +365,7 @@ SignedXml.prototype.checkSignature = function (xml, callback) {
 
   // Reset the references as only references from our re-parsed signedInfo node can be trusted
   this.references = [];
+  this.signedReferences = [];
 
   const unverifiedSignedInfoCanon = this.getCanonSignedInfoXml(doc);
   if (!unverifiedSignedInfoCanon) {
@@ -403,6 +405,7 @@ SignedXml.prototype.checkSignature = function (xml, callback) {
   }
 
   if (!this.validateReferences(doc)) {
+    this.signedReferences = []; // reset signedReferences
     if (!callback) {
       return false;
     } else {
@@ -492,6 +495,10 @@ SignedXml.prototype.validateSignatureValue = function (doc, callback) {
     this.validationErrors.push(
       "invalid signature: the signature value " + this.signatureValue + " is incorrect"
     );
+  if (!res) {
+    this.signedReferences = [];
+  }
+
   return res;
 };
 
@@ -584,6 +591,7 @@ SignedXml.prototype.validateReferences = function (doc) {
 
       return false;
     }
+    this.signedReferences.push(canonXml);
   }
   return true;
 };


### PR DESCRIPTION
cc @cjbarth 

Unfortunately, I've decided that the best way is to backport the API. 
Because we still want other libraries to use the API even if they are still on v2.x/v3.x

It is actually a much more quicker change than the libraries upgrading to say v6.x or v7.x
