### PR TITLE
Add implicit C14N when signing if no transforms specified

### DIFF
--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -423,10 +423,13 @@ export class SignedXml {
   }
 
   private getCanonReferenceXml(doc: Document, ref: Reference, node: Node) {
+    const transforms: string[] = [];
+    
     /**
      * Search for ancestor namespaces before canonicalization.
      */
     if (Array.isArray(ref.transforms)) {
+      transforms.push(...ref.transforms);
       ref.ancestorNamespaces = utils.findAncestorNs(doc, ref.xpath, this.namespaceResolver);
     }
 
@@ -434,8 +437,15 @@ export class SignedXml {
       inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList,
       ancestorNamespaces: ref.ancestorNamespaces,
     };
+    
+    if (
+      transforms.length === 0 ||
+      transforms[transforms.length - 1] === "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
+    ) {
+      transforms.push("http://www.w3.org/TR/2001/REC-xml-c14n-20010315");
+    }
 
-    return this.getCanonXml(ref.transforms, node, c14nOptions);
+    return this.getCanonXml(transforms, node, c14nOptions);
   }
 
   private calculateSignatureValue(doc: Document, callback?: ErrorFirstCallback<string>) {


### PR DESCRIPTION
When signing, the library currently does not apply any canonicalization to the referenced document being signed, unless explicitly specified in the `transforms` config property.

This behaviour differs from many other XML signature libraries such as javax.xml.crypto.dsig and signxml, who implicitly apply `http://www.w3.org/TR/2001/REC-xml-c14n-20010315` if the user does not specify any canonicalization transforms.

This PR proposes adding the same implicit canonicalization behaviour, to make the output more consistent with other implementations.

Related issues: https://github.com/node-saml/xml-crypto/issues/210 https://github.com/node-saml/xml-crypto/issues/212 https://github.com/node-saml/xml-crypto/issues/484 https://github.com/node-saml/xml-crypto/issues/486