### PR TITLE
Respect idAttribute when generating signatures.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,18 @@
+import { NamespacedId } from "./types";
+
+/** Well known namespaced ids */
+export const KNOWN_NAMESPACED_IDS: { [key: string]: NamespacedId } = {
+  /** WS-Security */
+  wssecurity: {
+    prefix: "wsu",
+    localName: "Id",
+    nameSpaceURI:
+      "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd",
+  },
+  /** Xml */
+  xml: {
+    prefix: "xml",
+    localName: "id",
+    nameSpaceURI: "http://www.w3.org/XML/1998/namespace",
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,11 +60,23 @@ export interface ObjectAttributes {
 }
 
 /**
+ * Namespaced id attribute.
+ */
+export interface NamespacedId {
+  /** Namespace prefix */
+  prefix: string;
+  /** Attribute local name */
+  localName: string;
+  /** Namespace URI */
+  nameSpaceURI: string;
+}
+
+/**
  * Options for the SignedXml constructor.
  */
 export interface SignedXmlOptions {
   idMode?: "wssecurity";
-  idAttribute?: string;
+  idAttribute?: string | NamespacedId;
   privateKey?: crypto.KeyLike;
   publicCert?: crypto.KeyLike;
   signatureAlgorithm?: SignatureAlgorithmType;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import * as xpath from "xpath";
-import type { NamespacePrefix } from "./types";
+import type { NamespacedId, NamespacePrefix } from "./types";
 import * as isDomNode from "@xmldom/is-dom-node";
 
 export function isArrayHasLength(array: unknown): array is unknown[] {
@@ -17,10 +17,17 @@ function attrEqualsImplicitly(attr: Attr, localName: string, namespace?: string,
   );
 }
 
-export function findAttr(element: Element, localName: string, namespace?: string) {
+export function findAttr(element: Element, id: string | NamespacedId) {
   for (let i = 0; i < element.attributes.length; i++) {
     const attr = element.attributes[i];
-
+    let localName: string;
+    let namespace: string | undefined;
+    if (typeof id === "string") {
+      localName = id;
+    } else {
+      localName = id.localName;
+      namespace = id.nameSpaceURI;
+    }
     if (
       attrEqualsExplicitly(attr, localName, namespace) ||
       attrEqualsImplicitly(attr, localName, namespace, element)

--- a/test/signature-unit-tests.spec.ts
+++ b/test/signature-unit-tests.spec.ts
@@ -85,7 +85,7 @@ describe("Signature unit tests", function () {
       expect(node.length, `xpath ${xpathArg} not found`).to.equal(1);
     }
 
-    function verifyAddsId(mode, nsMode, idAttribute:string|undefined = undefined) {
+    function verifyAddsId(mode, nsMode, idAttribute: string | undefined = undefined) {
       const xml = '<root><x xmlns="ns"></x><y attr="value"></y><z><w></w></z></root>';
       const sig = new SignedXml({ idMode: mode, idAttribute });
       sig.privateKey = fs.readFileSync("./test/static/client.pem");
@@ -114,7 +114,9 @@ describe("Signature unit tests", function () {
 
       const op = nsMode === "equal" ? "=" : "!=";
 
-      const xpathArg = `//*[local-name(.)='{elem}' and '_{id}' = @*[local-name(.)='${idAttribute || 'Id'}' and namespace-uri(.)${op}'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd']]`;
+      const xpathArg = `//*[local-name(.)='{elem}' and '_{id}' = @*[local-name(.)='${
+        idAttribute || "Id"
+      }' and namespace-uri(.)${op}'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd']]`;
 
       //verify each of the signed nodes now has an "Id" attribute with the right value
       nodeExists(doc, xpathArg.replace("{id}", "0").replace("{elem}", "x"));
@@ -123,7 +125,7 @@ describe("Signature unit tests", function () {
     }
 
     it("signer adds increasing different id attributes to elements with custom idAttribute", function () {
-      verifyAddsId(null, "different", 'myIdAttribute');
+      verifyAddsId(null, "different", "myIdAttribute");
     });
 
     it("signer adds increasing different id attributes to elements", function () {


### PR DESCRIPTION
Fixes #33
small fix to respect user provided idAttribute when generating id's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for namespaced ID attributes (e.g., WS‑Security and xml:id) when signing XML.
  * idAttribute option now accepts either a plain name or a namespaced identifier, so you can provide a custom attribute or a namespaced ID.
  * Generated IDs and reference lookups honor the provided attribute form (plain or namespaced) for consistent signing and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->