### PR TITLE
Deprecate getOriginalXmlWithIds()

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ To sign xml documents:
     - `existingPrefixes` - A hash of prefixes and namespaces `prefix: namespace` that shouldn't be in the signature because they already exist in the xml
 - `getSignedXml()` - returns the original xml document with the signature in it, **must be called only after `computeSignature`**
 - `getSignatureXml()` - returns just the signature part, **must be called only after `computeSignature`**
-- `getOriginalXmlWithIds()` - returns the original xml with Id attributes added on relevant elements (required for validation), **must be called only after `computeSignature`**
+- `getOriginalXmlWithIds()` - **[deprecated]** returns the original xml with Id attributes added on relevant elements, **must be called only after `computeSignature`**. This method is deprecated and will be removed in a future version. Use `ComputeSignatureOptionsLocation` to control where the signature will be placed in the original XML.
 
 To verify xml documents:
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ To sign xml documents:
     - `existingPrefixes` - A hash of prefixes and namespaces `prefix: namespace` that shouldn't be in the signature because they already exist in the xml
 - `getSignedXml()` - returns the original xml document with the signature in it, **must be called only after `computeSignature`**
 - `getSignatureXml()` - returns just the signature part, **must be called only after `computeSignature`**
-- `getOriginalXmlWithIds()` - **[deprecated]** returns the original xml with Id attributes added on relevant elements, **must be called only after `computeSignature`**. This method is deprecated and will be removed in a future version. Use `ComputeSignatureOptionsLocation` to control where the signature will be placed in the original XML.
+- `getOriginalXmlWithIds()` - **[deprecated]** returns the original xml with Id attributes added on relevant elements, **must be called only after `computeSignature`**. Use the `location` option of `computeSignature()` to place the signature, then `getSignedXml()`. See [how to specify the location of the signature](#how-to-specify-the-location-of-the-signature).
 
 To verify xml documents:
 

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -1403,13 +1403,14 @@ export class SignedXml {
   }
 
   /**
-   * Returns the original xml with Id attributes added on relevant elements (required for validation), must be called only after {@link computeSignature}
+   * Returns the original xml with Id attributes added on relevant elements, must be called only after {@link computeSignature}
    *
    * @returns The original XML with IDs.
+   * @deprecated This function is deprecated and will be removed in a future version. Use ComputeSignatureOptionsLocation to control where the signature will be placed in the original XML.
    */
-  getOriginalXmlWithIds(): string {
+  getOriginalXmlWithIds = deprecate((): string => {
     return this.originalXmlWithIds;
-  }
+  }, "`getOriginalXmlWithIds()` is deprecated and will be removed in a future version. Use ComputeSignatureOptionsLocation to control where the signature will be placed in the original XML.");
 
   /**
    * Returns the original xml document with the signature in it, must be called only after {@link computeSignature}

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -27,6 +27,12 @@ import * as hashAlgorithms from "./hash-algorithms";
 import * as signatureAlgorithms from "./signature-algorithms";
 import * as utils from "./utils";
 
+const warnOriginalXmlWithIds = deprecate(
+  () => {},
+  "`getOriginalXmlWithIds()` is deprecated and will be removed in a future version. Use the `location` option of `computeSignature()` to place the signature, then `getSignedXml()`.",
+  "XML_CRYPTO_GET_ORIGINAL_XML_WITH_IDS",
+);
+
 export class SignedXml {
   idMode?: "wssecurity";
   idAttributes: string[];
@@ -1406,11 +1412,13 @@ export class SignedXml {
    * Returns the original xml with Id attributes added on relevant elements, must be called only after {@link computeSignature}
    *
    * @returns The original XML with IDs.
-   * @deprecated This function is deprecated and will be removed in a future version. Use ComputeSignatureOptionsLocation to control where the signature will be placed in the original XML.
+   * @deprecated Will be removed in a future version. Use the `location` option of
+   * {@link computeSignature} to place the signature, then {@link getSignedXml}.
    */
-  getOriginalXmlWithIds = deprecate((): string => {
+  getOriginalXmlWithIds(): string {
+    warnOriginalXmlWithIds();
     return this.originalXmlWithIds;
-  }, "`getOriginalXmlWithIds()` is deprecated and will be removed in a future version. Use ComputeSignatureOptionsLocation to control where the signature will be placed in the original XML.");
+  }
 
   /**
    * Returns the original xml document with the signature in it, must be called only after {@link computeSignature}


### PR DESCRIPTION
As per the discussion in issue #512 , this PR removes the internal usages of the getOriginalXmlWithIds() function and marks it deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for the deprecated original-XML retrieval method, recommending the signature-location option with signed XML retrieval.
* **Public API**
  * The original-XML retrieval method remains available and now emits a deprecation warning when used.
* **Tests**
  * Updated assertions to validate signed XML output and confirm IDs and element attributes without including signature-related attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->