### PR TITLE
fix: use constant-time comparison for HMAC verification (#522)

### DIFF
--- a/src/signature-algorithms.ts
+++ b/src/signature-algorithms.ts
@@ -143,7 +143,17 @@ export class HmacSha1 implements SignatureAlgorithm {
       verifier.update(material);
       const res = verifier.digest("base64");
 
-      return res === signatureValue;
+      // Use constant-time comparison to prevent timing attacks (CWE-208)
+      // See: https://github.com/node-saml/xml-crypto/issues/522
+      try {
+        return crypto.timingSafeEqual(
+          Buffer.from(res, "base64"),
+          Buffer.from(signatureValue, "base64"),
+        );
+      } catch (e) {
+        // timingSafeEqual throws if buffer lengths don't match
+        return false;
+      }
     },
   );
 


### PR DESCRIPTION
Replace non-constant-time === operator with crypto.timingSafeEqual() to prevent timing side-channel attacks on HMAC signature verification.

Fixes #522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened the security of signature verification mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->