### PR TITLE
fix: collect all subset namespace prefixes when filtering ancestor namespaces

### DIFF
--- a/src/c14n-canonicalization.ts
+++ b/src/c14n-canonicalization.ts
@@ -96,7 +96,6 @@ export class C14nCanonicalization implements CanonicalizationOrTransformationAlg
     const nsListToRender: { prefix: string; namespaceURI: string }[] = [];
     const currNs = node.namespaceURI || "";
 
-    //handle the namespace of the node itself
     if (node.prefix && prefixesInScope.indexOf(node.prefix) === -1) {
       nsListToRender.push({
         prefix: node.prefix,
@@ -105,10 +104,8 @@ export class C14nCanonicalization implements CanonicalizationOrTransformationAlg
       prefixesInScope.push(node.prefix);
     }
 
-    //xmldom reports `xmlns="..."` as an attribute with no prefix, and a prefixed element's
-    //`namespaceURI` is its own namespace rather than the default one, so the declaration
-    //cannot be recovered from the node and has to be read off its attributes.
-    //https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
+    // The default namespace is independent of a prefixed element's namespaceURI.
+    // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
     let localDefaultNs: string | null = null;
     if (node.attributes) {
       for (i = 0; i < node.attributes.length; ++i) {

--- a/src/c14n-canonicalization.ts
+++ b/src/c14n-canonicalization.ts
@@ -97,17 +97,38 @@ export class C14nCanonicalization implements CanonicalizationOrTransformationAlg
     const currNs = node.namespaceURI || "";
 
     //handle the namespace of the node itself
-    if (node.prefix) {
-      if (prefixesInScope.indexOf(node.prefix) === -1) {
-        nsListToRender.push({
-          prefix: node.prefix,
-          namespaceURI: node.namespaceURI || defaultNsForPrefix[node.prefix],
-        });
-        prefixesInScope.push(node.prefix);
+    if (node.prefix && prefixesInScope.indexOf(node.prefix) === -1) {
+      nsListToRender.push({
+        prefix: node.prefix,
+        namespaceURI: node.namespaceURI || defaultNsForPrefix[node.prefix],
+      });
+      prefixesInScope.push(node.prefix);
+    }
+
+    //xmldom reports `xmlns="..."` as an attribute with no prefix, and a prefixed element's
+    //`namespaceURI` is its own namespace rather than the default one, so the declaration
+    //cannot be recovered from the node and has to be read off its attributes.
+    //https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
+    let localDefaultNs: string | null = null;
+    if (node.attributes) {
+      for (i = 0; i < node.attributes.length; ++i) {
+        if (node.attributes[i].name === "xmlns") {
+          localDefaultNs = node.attributes[i].value;
+        }
       }
-    } else if (defaultNs !== currNs) {
-      //new default ns
-      newDefaultNs = node.namespaceURI || "";
+    }
+
+    let nodeDefaultNs: string;
+    if (localDefaultNs !== null) {
+      nodeDefaultNs = localDefaultNs;
+    } else if (node.prefix) {
+      nodeDefaultNs = defaultNs;
+    } else {
+      nodeDefaultNs = currNs;
+    }
+
+    if (nodeDefaultNs !== defaultNs) {
+      newDefaultNs = nodeDefaultNs;
       res.push(' xmlns="', newDefaultNs, '"');
     }
 

--- a/src/c14n-canonicalization.ts
+++ b/src/c14n-canonicalization.ts
@@ -173,6 +173,9 @@ export class C14nCanonicalization implements CanonicalizationOrTransformationAlg
 
         if (!alreadyListed) {
           nsListToRender.push(ancestorNamespace);
+          if (!ancestorNamespace.prefix) {
+            newDefaultNs = ancestorNamespace.namespaceURI;
+          }
         }
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -287,17 +287,10 @@ export function findAncestorNs(
   // Remove duplicate on ancestor namespace
   const ancestorNs = collectAncestorNamespaces(docSubset[0]);
   const ancestorNsWithoutDuplicate: NamespacePrefix[] = [];
-  for (let i = 0; i < ancestorNs.length; i++) {
-    let notOnTheList = true;
-    for (const v in ancestorNsWithoutDuplicate) {
-      if (ancestorNsWithoutDuplicate[v].prefix === ancestorNs[i].prefix) {
-        notOnTheList = false;
-        break;
-      }
-    }
-
-    if (notOnTheList) {
-      ancestorNsWithoutDuplicate.push(ancestorNs[i]);
+  for (const ns of ancestorNs) {
+    const isDuplicate = ancestorNsWithoutDuplicate.some((seen) => seen.prefix === ns.prefix);
+    if (!isDuplicate) {
+      ancestorNsWithoutDuplicate.push(ns);
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -241,7 +241,7 @@ function findSubsetNSPrefixes(subset: Element): Set<string> {
   const subsetAttributes = subset.attributes;
   for (let k = 0; k < subsetAttributes.length; k++) {
     const nodeName = subsetAttributes[k].nodeName;
-    if (/^xmlns:?/.test(nodeName)) {
+    if (nodeName === "xmlns" || nodeName.startsWith("xmlns:")) {
       prefixes.add(nodeName.replace(/^xmlns:?/, ""));
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -221,15 +221,35 @@ function collectAncestorNamespaces(
   return collectAncestorNamespaces(parent, nsArray);
 }
 
-function findNSPrefix(subset) {
+/**
+ * Collect all namespace prefixes declared directly on a subset element.
+ *
+ * This includes every `xmlns:*` attribute on the element as well as the
+ * element's own namespace prefix (or `""` for the default namespace). The
+ * result is used by {@link findAncestorNs} to decide which ancestor namespace
+ * declarations are already in scope and therefore must not be hoisted onto the
+ * subset root during non-exclusive C14N.
+ *
+ * The previous single-return implementation (`findNSPrefix`) stopped at the
+ * *first* `xmlns:*` attribute, so elements that declare more than one
+ * namespace (e.g. `<Body xmlns:enc="…">` in the default namespace) caused the
+ * inherited default namespace to be hoisted even though the C14N serializer
+ * already renders it, producing a duplicate `xmlns="…"` declaration.
+ */
+function findSubsetNSPrefixes(subset: Element): Set<string> {
+  const prefixes = new Set<string>();
   const subsetAttributes = subset.attributes;
   for (let k = 0; k < subsetAttributes.length; k++) {
     const nodeName = subsetAttributes[k].nodeName;
-    if (nodeName.search(/^xmlns:?/) !== -1) {
-      return nodeName.replace(/^xmlns:?/, "");
+    if (/^xmlns:?/.test(nodeName)) {
+      prefixes.add(nodeName.replace(/^xmlns:?/, ""));
     }
   }
-  return subset.prefix || "";
+  // Always include the element's own prefix (empty string for the default
+  // namespace) so that the C14N serializer's own rendering of that namespace
+  // is not duplicated by hoisting.
+  prefixes.add(subset.prefix || "");
+  return prefixes;
 }
 
 function isElementSubset(docSubset: Node[]): docSubset is Element[] {
@@ -283,9 +303,9 @@ export function findAncestorNs(
 
   // Remove namespaces which are already declared in the subset with the same prefix
   const returningNs: NamespacePrefix[] = [];
-  const subsetNsPrefix = findNSPrefix(docSubset[0]);
+  const subsetNsPrefixes = findSubsetNSPrefixes(docSubset[0]);
   for (const ancestorNs of ancestorNsWithoutDuplicate) {
-    if (ancestorNs.prefix !== subsetNsPrefix) {
+    if (!subsetNsPrefixes.has(ancestorNs.prefix)) {
       returningNs.push(ancestorNs);
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -221,21 +221,6 @@ function collectAncestorNamespaces(
   return collectAncestorNamespaces(parent, nsArray);
 }
 
-/**
- * Collect all namespace prefixes declared directly on a subset element.
- *
- * This includes every `xmlns:*` attribute on the element as well as the
- * element's own namespace prefix (or `""` for the default namespace). The
- * result is used by {@link findAncestorNs} to decide which ancestor namespace
- * declarations are already in scope and therefore must not be hoisted onto the
- * subset root during non-exclusive C14N.
- *
- * The previous single-return implementation (`findNSPrefix`) stopped at the
- * *first* `xmlns:*` attribute, so elements that declare more than one
- * namespace (e.g. `<Body xmlns:enc="…">` in the default namespace) caused the
- * inherited default namespace to be hoisted even though the C14N serializer
- * already renders it, producing a duplicate `xmlns="…"` declaration.
- */
 function findSubsetNSPrefixes(subset: Element): Set<string> {
   const prefixes = new Set<string>();
   const subsetAttributes = subset.attributes;
@@ -245,9 +230,8 @@ function findSubsetNSPrefixes(subset: Element): Set<string> {
       prefixes.add(nodeName.replace(/^xmlns:?/, ""));
     }
   }
-  // Always include the element's own prefix (empty string for the default
-  // namespace) so that the C14N serializer's own rendering of that namespace
-  // is not duplicated by hoisting.
+  // C14N already renders the element's own namespace; hoisting it would duplicate the declaration.
+  // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
   prefixes.add(subset.prefix || "");
   return prefixes;
 }
@@ -284,7 +268,6 @@ export function findAncestorNs(
     throw new Error("Document subset must be list of elements");
   }
 
-  // Remove duplicate on ancestor namespace
   const ancestorNs = collectAncestorNamespaces(docSubset[0]);
   const ancestorNsWithoutDuplicate: NamespacePrefix[] = [];
   for (const ns of ancestorNs) {
@@ -294,7 +277,6 @@ export function findAncestorNs(
     }
   }
 
-  // Remove namespaces which are already declared in the subset with the same prefix
   const returningNs: NamespacePrefix[] = [];
   const subsetNsPrefixes = findSubsetNSPrefixes(docSubset[0]);
   for (const ancestorNs of ancestorNsWithoutDuplicate) {

--- a/test/c14n-non-exclusive-unit-tests.spec.ts
+++ b/test/c14n-non-exclusive-unit-tests.spec.ts
@@ -1,15 +1,22 @@
 import { expect } from "chai";
 
-import { C14nCanonicalization } from "../src/c14n-canonicalization";
+import {
+  C14nCanonicalization,
+  C14nCanonicalizationWithComments,
+} from "../src/c14n-canonicalization";
 import * as xmldom from "@xmldom/xmldom";
 import * as xpath from "xpath";
 import * as utils from "../src/utils";
 import * as isDomNode from "@xmldom/is-dom-node";
 
-const test_C14nCanonicalization = function (xml, xpathArg, expected) {
+const test_C14nCanonicalization = function (
+  xml: string,
+  xpathArg: string,
+  expected: string,
+  can = new C14nCanonicalization(),
+) {
   const doc = new xmldom.DOMParser().parseFromString(xml);
   const node = xpath.select1(xpathArg, doc);
-  const can = new C14nCanonicalization();
 
   isDomNode.assertIsNodeLike(node);
   const result = can
@@ -118,11 +125,9 @@ describe("C14N non-exclusive canonicalization tests", function () {
   });
 
   it("findAncestorNs: Should not hoist default namespace when subset also declares a prefixed namespace", function () {
-    // child2 is in the default namespace (inherited from root) and also
-    // declares xmlns:enc.  The default namespace must not be hoisted because
-    // the C14N serializer already renders it; previously findNSPrefix stopped
-    // at the first xmlns:* attribute ("enc") and missed the inherited "".
-    const xml = "<root xmlns='bbb'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
+    // The element's own default namespace must be rendered only once.
+    // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
+    const xml = '<root xmlns="urn:default"><child1><child2 xmlns:enc="urn:enc"/></child1></root>';
     const xpath = "//*[local-name()='child2']";
     const expected = [];
 
@@ -130,24 +135,22 @@ describe("C14N non-exclusive canonicalization tests", function () {
   });
 
   it("findAncestorNs: Should hoist non-default ancestor namespaces when subset is in default namespace", function () {
-    // child2 is in the default namespace and declares xmlns:enc, but its
-    // ancestor also declares xmlns:aaa which child2 does not redeclare.
-    // xmlns:aaa must still be hoisted; only the default namespace is suppressed.
+    // Inclusive C14N retains ancestor bindings even when the subset does not visibly use them.
+    // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#DataModel
     const xml =
-      "<root xmlns='bbb' xmlns:aaa='zzz'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
+      '<root xmlns="urn:default" xmlns:aaa="urn:aaa"><child1><child2 xmlns:enc="urn:enc"/></child1></root>';
     const xpath = "//*[local-name()='child2']";
-    const expected = [{ prefix: "aaa", namespaceURI: "zzz" }];
+    const expected = [{ prefix: "aaa", namespaceURI: "urn:aaa" }];
 
     test_findAncestorNs(xml, xpath, expected);
   });
 
   it("findAncestorNs: Should not suppress ancestor namespace for non-namespace attribute starting with 'xmlns'", function () {
-    // xmlnsfoo is an ordinary attribute, not a namespace declaration.
-    // findSubsetNSPrefixes must not add "foo" to the suppression set, so
-    // an inherited xmlns:foo declaration on an ancestor is still hoisted.
-    const xml = "<root xmlns:foo='zzz'><child1><child2 xmlnsfoo='bar'></child2></child1></root>";
+    // Only xmlns and xmlns:* declare namespaces; xmlnsfoo must not hide an inherited binding.
+    // https://www.w3.org/TR/REC-xml-names/#ns-decl
+    const xml = '<root xmlns:foo="urn:foo"><child1><child2 xmlnsfoo="bar"/></child1></root>';
     const xpath = "//*[local-name()='child2']";
-    const expected = [{ prefix: "foo", namespaceURI: "zzz" }];
+    const expected = [{ prefix: "foo", namespaceURI: "urn:foo" }];
 
     test_findAncestorNs(xml, xpath, expected);
   });
@@ -246,17 +249,85 @@ describe("C14N non-exclusive canonicalization tests", function () {
     test_C14nCanonicalization(xml, xpath, expected);
   });
 
-  it("C14n: Should not produce duplicate default namespace when subset declares a prefixed namespace", function () {
-    // child2 is in the default namespace and also declares xmlns:enc.
-    // The C14N output must contain exactly one xmlns="bbb" declaration.
-    // Previously findNSPrefix returned "enc" (the first xmlns:* attribute),
-    // leaving the default namespace in the ancestor list; the C14N serializer
-    // then rendered it twice — once from the element itself and once from the
-    // hoisted ancestor entry.
-    const xml = "<root xmlns='bbb'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
-    const xpath = "//*[local-name()='child2']";
-    const expected = '<child2 xmlns="bbb" xmlns:enc="ccc"></child2>';
+  for (const Canonicalization of [C14nCanonicalization, C14nCanonicalizationWithComments]) {
+    describe(`${Canonicalization.name}: subset namespace declarations`, function () {
+      it("does not duplicate the default namespace when the subset declares a prefixed namespace", function () {
+        // Render the inherited default namespace exactly once on the subset root.
+        // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
+        test_C14nCanonicalization(
+          '<root xmlns="urn:default"><child1><child2 xmlns:enc="urn:enc"/></child1></root>',
+          "//*[local-name()='child2']",
+          '<child2 xmlns="urn:default" xmlns:enc="urn:enc"></child2>',
+          new Canonicalization(),
+        );
+      });
 
-    test_C14nCanonicalization(xml, xpath, expected);
-  });
+      it("does not duplicate the default namespace for the reported #538 document", function () {
+        // Literal reproduction from https://github.com/node-saml/xml-crypto/issues/538:
+        // a subset root inheriting a default namespace while declaring a prefixed one,
+        // with a prefixed child that must resolve against the local declaration.
+        // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
+        test_C14nCanonicalization(
+          '<Root xmlns="http://example.com/root">' +
+            '<Body Id="B" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">' +
+            "<enc:CipherValue>x</enc:CipherValue></Body></Root>",
+          "//*[local-name()='Body']",
+          '<Body xmlns="http://example.com/root" xmlns:enc="http://www.w3.org/2001/04/xmlenc#" Id="B">' +
+            "<enc:CipherValue>x</enc:CipherValue></Body>",
+          new Canonicalization(),
+        );
+      });
+
+      it("retains unused ancestor prefixes alongside the default and local namespaces", function () {
+        // Inclusive C14N preserves every in-scope namespace, including unused ancestor bindings.
+        // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#DataModel
+        test_C14nCanonicalization(
+          '<root xmlns="urn:default" xmlns:aaa="urn:aaa"><child2 xmlns:enc="urn:enc"/></root>',
+          "//*[local-name()='child2']",
+          '<child2 xmlns="urn:default" xmlns:aaa="urn:aaa" xmlns:enc="urn:enc"></child2>',
+          new Canonicalization(),
+        );
+      });
+
+      for (const declarations of [
+        'xmlns:a="urn:local-a" xmlns:b="urn:local-b"',
+        'xmlns:b="urn:local-b" xmlns:a="urn:local-a"',
+      ]) {
+        it(`uses both local prefix bindings with ${declarations}`, function () {
+          // Local declarations override ancestor bindings regardless of declaration order.
+          // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#DataModel
+          test_C14nCanonicalization(
+            '<root xmlns:a="urn:ancestor-a" xmlns:b="urn:ancestor-b">' +
+              `<child2 ${declarations}><a:item/><b:item/></child2></root>`,
+            "//*[local-name()='child2']",
+            '<child2 xmlns:a="urn:local-a" xmlns:b="urn:local-b"><a:item></a:item><b:item></b:item></child2>',
+            new Canonicalization(),
+          );
+        });
+      }
+
+      it("renders the default namespace on a prefixed apex that redeclares it", function () {
+        // Every namespace in scope at the apex is rendered there, including the default one.
+        // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
+        test_C14nCanonicalization(
+          '<root xmlns="urn:default"><p:child2 xmlns:p="urn:p" xmlns="urn:default"/></root>',
+          "//*[local-name()='child2']",
+          '<p:child2 xmlns="urn:default" xmlns:p="urn:p"></p:child2>',
+          new Canonicalization(),
+        );
+      });
+
+      it("does not restore a default namespace explicitly cleared on a prefixed root", function () {
+        // An empty default declaration removes the inherited binding; no reset is needed at the apex.
+        // https://www.w3.org/TR/REC-xml-names/#defaulting
+        // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
+        test_C14nCanonicalization(
+          '<root xmlns="urn:ancestor"><p:child2 xmlns:p="urn:p" xmlns=""><item/></p:child2></root>',
+          "//*[local-name()='child2']",
+          '<p:child2 xmlns:p="urn:p"><item></item></p:child2>',
+          new Canonicalization(),
+        );
+      });
+    });
+  }
 });

--- a/test/c14n-non-exclusive-unit-tests.spec.ts
+++ b/test/c14n-non-exclusive-unit-tests.spec.ts
@@ -142,6 +142,18 @@ describe("C14N non-exclusive canonicalization tests", function () {
     test_findAncestorNs(xml, xpath, expected);
   });
 
+  it("findAncestorNs: Should not suppress ancestor namespace for non-namespace attribute starting with 'xmlns'", function () {
+    // xmlnsfoo is an ordinary attribute, not a namespace declaration.
+    // findSubsetNSPrefixes must not add "foo" to the suppression set, so
+    // an inherited xmlns:foo declaration on an ancestor is still hoisted.
+    const xml =
+      "<root xmlns:foo='zzz'><child1><child2 xmlnsfoo='bar'></child2></child1></root>";
+    const xpath = "//*[local-name()='child2']";
+    const expected = [{ prefix: "foo", namespaceURI: "zzz" }];
+
+    test_findAncestorNs(xml, xpath, expected);
+  });
+
   // Tests for c14nCanonicalization
   it("C14n: Correctly picks up root ancestor namespace", function () {
     const xml = "<root xmlns:aaa='bbb'><child1><child2></child2></child1></root>";

--- a/test/c14n-non-exclusive-unit-tests.spec.ts
+++ b/test/c14n-non-exclusive-unit-tests.spec.ts
@@ -122,8 +122,7 @@ describe("C14N non-exclusive canonicalization tests", function () {
     // declares xmlns:enc.  The default namespace must not be hoisted because
     // the C14N serializer already renders it; previously findNSPrefix stopped
     // at the first xmlns:* attribute ("enc") and missed the inherited "".
-    const xml =
-      "<root xmlns='bbb'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
+    const xml = "<root xmlns='bbb'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
     const xpath = "//*[local-name()='child2']";
     const expected = [];
 
@@ -146,8 +145,7 @@ describe("C14N non-exclusive canonicalization tests", function () {
     // xmlnsfoo is an ordinary attribute, not a namespace declaration.
     // findSubsetNSPrefixes must not add "foo" to the suppression set, so
     // an inherited xmlns:foo declaration on an ancestor is still hoisted.
-    const xml =
-      "<root xmlns:foo='zzz'><child1><child2 xmlnsfoo='bar'></child2></child1></root>";
+    const xml = "<root xmlns:foo='zzz'><child1><child2 xmlnsfoo='bar'></child2></child1></root>";
     const xpath = "//*[local-name()='child2']";
     const expected = [{ prefix: "foo", namespaceURI: "zzz" }];
 
@@ -255,8 +253,7 @@ describe("C14N non-exclusive canonicalization tests", function () {
     // leaving the default namespace in the ancestor list; the C14N serializer
     // then rendered it twice — once from the element itself and once from the
     // hoisted ancestor entry.
-    const xml =
-      "<root xmlns='bbb'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
+    const xml = "<root xmlns='bbb'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
     const xpath = "//*[local-name()='child2']";
     const expected = '<child2 xmlns="bbb" xmlns:enc="ccc"></child2>';
 

--- a/test/c14n-non-exclusive-unit-tests.spec.ts
+++ b/test/c14n-non-exclusive-unit-tests.spec.ts
@@ -117,6 +117,31 @@ describe("C14N non-exclusive canonicalization tests", function () {
     test_findAncestorNs(xml, xpath, expected);
   });
 
+  it("findAncestorNs: Should not hoist default namespace when subset also declares a prefixed namespace", function () {
+    // child2 is in the default namespace (inherited from root) and also
+    // declares xmlns:enc.  The default namespace must not be hoisted because
+    // the C14N serializer already renders it; previously findNSPrefix stopped
+    // at the first xmlns:* attribute ("enc") and missed the inherited "".
+    const xml =
+      "<root xmlns='bbb'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
+    const xpath = "//*[local-name()='child2']";
+    const expected = [];
+
+    test_findAncestorNs(xml, xpath, expected);
+  });
+
+  it("findAncestorNs: Should hoist non-default ancestor namespaces when subset is in default namespace", function () {
+    // child2 is in the default namespace and declares xmlns:enc, but its
+    // ancestor also declares xmlns:aaa which child2 does not redeclare.
+    // xmlns:aaa must still be hoisted; only the default namespace is suppressed.
+    const xml =
+      "<root xmlns='bbb' xmlns:aaa='zzz'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
+    const xpath = "//*[local-name()='child2']";
+    const expected = [{ prefix: "aaa", namespaceURI: "zzz" }];
+
+    test_findAncestorNs(xml, xpath, expected);
+  });
+
   // Tests for c14nCanonicalization
   it("C14n: Correctly picks up root ancestor namespace", function () {
     const xml = "<root xmlns:aaa='bbb'><child1><child2></child2></child1></root>";
@@ -207,6 +232,21 @@ describe("C14N non-exclusive canonicalization tests", function () {
       "<root xmlns='bbb'><child1><cc:child2 xmlns:cc='ddd'><cc:child3></cc:child3></cc:child2></child1></root>";
     const xpath = "//*[local-name()='child3']";
     const expected = '<cc:child3 xmlns="bbb" xmlns:cc="ddd"></cc:child3>';
+
+    test_C14nCanonicalization(xml, xpath, expected);
+  });
+
+  it("C14n: Should not produce duplicate default namespace when subset declares a prefixed namespace", function () {
+    // child2 is in the default namespace and also declares xmlns:enc.
+    // The C14N output must contain exactly one xmlns="bbb" declaration.
+    // Previously findNSPrefix returned "enc" (the first xmlns:* attribute),
+    // leaving the default namespace in the ancestor list; the C14N serializer
+    // then rendered it twice — once from the element itself and once from the
+    // hoisted ancestor entry.
+    const xml =
+      "<root xmlns='bbb'><child1><child2 xmlns:enc='ccc'></child2></child1></root>";
+    const xpath = "//*[local-name()='child2']";
+    const expected = '<child2 xmlns="bbb" xmlns:enc="ccc"></child2>';
 
     test_C14nCanonicalization(xml, xpath, expected);
   });

--- a/test/c14n-non-exclusive-unit-tests.spec.ts
+++ b/test/c14n-non-exclusive-unit-tests.spec.ts
@@ -317,6 +317,17 @@ describe("C14N non-exclusive canonicalization tests", function () {
         );
       });
 
+      it("omits a descendant default namespace already hoisted onto the subset root", function () {
+        // https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel
+        test_C14nCanonicalization(
+          '<root xmlns="urn:default" xmlns:p="urn:p">' +
+            '<p:target><p:child xmlns="urn:default"/></p:target></root>',
+          "//*[local-name()='target']",
+          '<p:target xmlns="urn:default" xmlns:p="urn:p"><p:child></p:child></p:target>',
+          new Canonicalization(),
+        );
+      });
+
       it("does not restore a default namespace explicitly cleared on a prefixed root", function () {
         // An empty default declaration removes the inherited binding; no reset is needed at the apex.
         // https://www.w3.org/TR/REC-xml-names/#defaulting

--- a/test/canonicalization-unit-tests.spec.ts
+++ b/test/canonicalization-unit-tests.spec.ts
@@ -1,9 +1,12 @@
 import { expect } from "chai";
 
-import { ExclusiveCanonicalization } from "../src/exclusive-canonicalization";
+import {
+  ExclusiveCanonicalization,
+  ExclusiveCanonicalizationWithComments,
+} from "../src/exclusive-canonicalization";
 import * as xmldom from "@xmldom/xmldom";
 import * as xpath from "xpath";
-import { SignedXml } from "../src/index";
+import { findAncestorNs, SignedXml } from "../src/index";
 import * as isDomNode from "@xmldom/is-dom-node";
 
 const compare = function (
@@ -28,6 +31,50 @@ const compare = function (
 };
 
 describe("Canonicalization unit tests", function () {
+  for (const Canonicalization of [
+    ExclusiveCanonicalization,
+    ExclusiveCanonicalizationWithComments,
+  ]) {
+    describe(`${Canonicalization.name}: configured inclusive namespaces`, function () {
+      const xml =
+        '<root xmlns:b="urn:ancestor" xmlns:c="urn:inherited">' +
+        '<target xmlns:a="urn:a" xmlns:b="urn:local" type="b:Kind"/></root>';
+      const selector = "//*[local-name()='target']";
+
+      it("retains local and inherited bindings requested by the caller", function () {
+        // PrefixList includes QName-value bindings without replacing local declarations with ancestors.
+        // https://www.w3.org/TR/xml-exc-c14n/#sec-Specification
+        const doc = new xmldom.DOMParser().parseFromString(xml);
+        const node = xpath.select1(selector, doc);
+        isDomNode.assertIsElementNode(node);
+
+        const result = new Canonicalization().process(node, {
+          ancestorNamespaces: findAncestorNs(doc, selector),
+          inclusiveNamespacesPrefixList: ["b", "c"],
+        });
+
+        expect(result).to.equal(
+          '<target xmlns:b="urn:local" xmlns:c="urn:inherited" type="b:Kind"></target>',
+        );
+      });
+
+      it("omits non-visible bindings when the caller supplies an empty PrefixList", function () {
+        // Prefixes used only in attribute values are not visibly utilized in exclusive C14N.
+        // https://www.w3.org/TR/xml-exc-c14n/#def-visibly-utilizes
+        const doc = new xmldom.DOMParser().parseFromString(xml);
+        const node = xpath.select1(selector, doc);
+        isDomNode.assertIsElementNode(node);
+
+        const result = new Canonicalization().process(node, {
+          ancestorNamespaces: findAncestorNs(doc, selector),
+          inclusiveNamespacesPrefixList: [],
+        });
+
+        expect(result).to.equal('<target type="b:Kind"></target>');
+      });
+    });
+  }
+
   it("Exclusive canonicalization works on xml with no namespaces", function () {
     compare("<root><child>123</child></root>", "//*", "<root><child>123</child></root>");
   });


### PR DESCRIPTION
  ---
  Fixes #538
  
  Problem

  `findNSPrefix` returned only the first xmlns:* attribute found on a subset
  element. `findAncestorNs` then used that single prefix to decide which ancestor
  namespace declarations to suppress — so any subset element that declared more
  than one namespace would silently let the others through.

  The concrete trigger is SMPTE ST 430-3 ETMs, where the XML signature covers
  `<AuthenticatedPrivate xmlns:enc="http://www.w3.org/2001/04/xmlenc#">` as a
  subset reference. That element is in the default namespace inherited from the
  document root, and also declares xmlns:enc. findNSPrefix returned "enc",
  leaving `{prefix: "", namespaceURI: "…ETM…"}` in the ancestor list. The C14N
  serializer then rendered the default namespace twice — once from the element
  itself via the defaultNs != currNs branch, and once from the hoisted ancestor
  entry — producing a digest that no conformant implementation would ever match.

  Fix

  Replace `findNSPrefix` (returns a single string) with `findSubsetNSPrefixes`
  (returns a Set<string>) that collects every xmlns:* attribute on the subset
  element and always includes the element's own namespace prefix ("" for the
  default namespace). findAncestorNs now uses Set.has() for the filter.

  The change is backward-compatible: it can only suppress more ancestor entries
  than before — no previously-hoisted namespace starts being retained.

  Tests added

  - findAncestorNs: default namespace is not hoisted when the subset also
  declares a prefixed namespace
  - findAncestorNs: non-default ancestor namespaces are still hoisted correctly
  in the same scenario
  - C14n: end-to-end check that the canonical output contains exactly one
  xmlns="…" declaration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML canonicalization for elements inheriting default namespaces while declaring prefixed namespaces.
  * Prevented duplicate or incorrectly hoisted namespace declarations.
  * Preserved valid ancestor namespace declarations and correctly handled namespace overrides and explicit clearing.
  * Correctly handled ordinary attributes beginning with `xmlns`.

* **Tests**
  * Added regression coverage for default, prefixed, and inherited namespace handling.
  * Verified behavior across canonicalization modes, including comment-preserving output.
  * Added coverage for inclusive namespace configuration and unrelated ancestor namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->