### PR TITLE
feat!: shrink the public export surface to what it means to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,47 @@
 
 ## Upgrading
 
+### Upgrading to 7.0
+
+The package used to re-export everything in its internal `utils` module, so helpers written
+for `signed-xml.ts` became public API by accident. The export list is explicit now and the
+following are no longer exported:
+
+| Removed                                                               | Instead                                                                                                                                                                                 |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `findAttr`, `findChildren`, `findChilds`, `isDescendantOf`            | use a DOM API, or [xpath](https://github.com/goto100/xpath)                                                                                                                             |
+| `encodeSpecialCharactersInAttribute`, `encodeSpecialCharactersInText` | these implement [c14n special-character normalization](https://www.w3.org/TR/xml-c14n#ProcessingModel); a serializer such as [xmldom](https://github.com/xmldom/xmldom) escapes for you |
+| `isArrayHasLength`                                                    | `Array.isArray(x) && x.length > 0`                                                                                                                                                      |
+| `validateDigestValue`                                                 | `crypto.timingSafeEqual(Buffer.from(a, "base64"), Buffer.from(b, "base64"))` — it throws on a length mismatch, which counts as unequal                                                  |
+| `BASE64_REGEX`, `EXTRACT_X509_CERTS`, `PEM_FORMAT_REGEX`              | no replacement; these were internal parsing details                                                                                                                                     |
+
+`derToPem`, `pemToDer`, `normalizePem` and `findAncestorNs` are still exported. See
+[exports](#exports) for the whole surface.
+
+`xpath` was never exported by 6.x despite being documented here; the README examples now
+require the [xpath](https://github.com/goto100/xpath) package directly, and its `select()`
+takes the expression first.
+
+Reaching past the entry point no longer resolves either. `package.json` declares an `exports`
+map, so a deep import such as `require("xml-crypto/lib/hash-algorithms.js")` fails with
+`ERR_PACKAGE_PATH_NOT_EXPORTED` instead of quietly depending on the build layout. The bundled
+algorithm classes are still reachable, through the registries that name them:
+
+```js
+const { SignedXml } = require("xml-crypto");
+
+// before
+const { Sha256 } = require("xml-crypto/lib/hash-algorithms.js");
+// after
+const Sha256 = new SignedXml().HashAlgorithms["http://www.w3.org/2001/04/xmlenc#sha256"];
+```
+
+`SignatureAlgorithms` and `CanonicalizationAlgorithms` work the same way. If you need
+something from `lib/` that no registry names, please open an issue rather than reaching for the
+path — that is the conversation the `exports` map exists to start.
+
+### Upgrading to 6.0
+
 The `.getReferences()` AND the `.references` APIs are deprecated.
 Please do not attempt to access them. The content in them should be treated as unsigned.
 
@@ -150,16 +191,16 @@ new SignedXml({
 });
 ```
 
-You can use any dom parser you want in your code (or none, depending on your usage). This sample uses [xmldom](https://github.com/xmldom/xmldom), so you should install it first:
+You can use any dom parser you want in your code (or none, depending on your usage). This sample uses [xmldom](https://github.com/xmldom/xmldom) to parse and [xpath](https://github.com/goto100/xpath) to select, so install those first:
 
 ```shell
-npm install @xmldom/xmldom
+npm install @xmldom/xmldom xpath
 ```
 
 Example:
 
 ```javascript
-var select = require("xml-crypto").xpath,
+var select = require("xpath").select,
   dom = require("@xmldom/xmldom").DOMParser,
   SignedXml = require("xml-crypto").SignedXml,
   fs = require("fs");
@@ -173,8 +214,8 @@ var doc = new dom().parseFromString(xml);
 // good: see below
 
 var signature = select(
-  doc,
   "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']",
+  doc,
 )[0];
 var sig = new SignedXml({ publicCert: fs.readFileSync("client_public.pem") });
 sig.loadSignature(signature);
@@ -238,10 +279,30 @@ You might find it difficult to guess such transforms, but there are typical tran
 
 ## API
 
-### xpath
+### Exports
 
-See [xpath.js](https://github.com/yaronn/xpath.js) for usage. Note that this is actually using
-[another library](https://github.com/goto100/xpath) as the underlying implementation.
+The package exports these values:
+
+| Export                                                               | Purpose                                                                                           |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `SignedXml`                                                          | signing and verification — see below                                                              |
+| `C14nCanonicalization`, `C14nCanonicalizationWithComments`           | the [canonicalization algorithms](#canonicalization-and-transformation-algorithms)                |
+| `ExclusiveCanonicalization`, `ExclusiveCanonicalizationWithComments` | as above, exclusive                                                                               |
+| `findAncestorNs`                                                     | ancestor namespaces for a document subset, for [custom canonicalization](#customizing-algorithms) |
+| `derToPem`, `pemToDer`, `normalizePem`                               | [key-format conversion](#x509--key-formats)                                                       |
+| `createOptionalCallbackFunction`                                     | adds a callback form to a synchronous algorithm method                                            |
+
+Plus the types `CanonicalizationAlgorithmType`, `CanonicalizationOrTransformAlgorithmType`,
+`CanonicalizationOrTransformationAlgorithm`,
+`CanonicalizationOrTransformationAlgorithmProcessOptions`, `ComputeSignatureOptions`,
+`ComputeSignatureOptionsLocation`, `ErrorFirstCallback`, `GetKeyInfoContentArgs`,
+`HashAlgorithm`, `HashAlgorithmType`, `NamespacePrefix`, `ObjectAttributes`, `Reference`,
+`RenderedNamespace`, `SignatureAlgorithm`, `SignatureAlgorithmType`, `SignedXmlOptions` and
+`TransformAlgorithm`.
+
+Anything not on this list is internal. `package.json` declares an `exports` map naming only
+this entry point, so a path into `lib/` no longer resolves and the list above is the whole
+surface rather than a convention.
 
 ### SignedXml
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,15 @@
     "LoneRifle <LoneRifle@users.noreply.github.com>",
     "Chris Barth <chrisjbarth@hotmail.com>"
   ],
-  "main": "./lib",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "files": [
     "lib",
     "LICENSE",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,30 @@ export {
   ExclusiveCanonicalizationWithComments,
 } from "./exclusive-canonicalization";
 export { SignedXml } from "./signed-xml";
-export * from "./types";
-export * from "./utils";
+
+export type {
+  CanonicalizationAlgorithmType,
+  CanonicalizationOrTransformAlgorithmType,
+  CanonicalizationOrTransformationAlgorithm,
+  CanonicalizationOrTransformationAlgorithmProcessOptions,
+  ComputeSignatureOptions,
+  ComputeSignatureOptionsLocation,
+  ErrorFirstCallback,
+  GetKeyInfoContentArgs,
+  HashAlgorithm,
+  HashAlgorithmType,
+  NamespacePrefix,
+  ObjectAttributes,
+  Reference,
+  RenderedNamespace,
+  SignatureAlgorithm,
+  SignatureAlgorithmType,
+  SignedXmlOptions,
+  TransformAlgorithm,
+} from "./types";
+export { createOptionalCallbackFunction } from "./types";
+
+// Key-format conversion, and the ancestor-namespace lookup an implementer of a custom
+// canonicalization algorithm needs. Everything else in `./utils` is internal to this
+// package: it is exported from that module for its siblings, not for consumers.
+export { derToPem, findAncestorNs, normalizePem, pemToDer } from "./utils";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,7 @@ export function encodeSpecialCharactersInText(text: string): string {
  *  - 'preeb' and 'posteb' lines are limited to 64 characters, but
  *     should not cause any issues in context of PKIX, PKCS and CMS.
  */
-export const PEM_FORMAT_REGEX = new RegExp(
+const PEM_FORMAT_REGEX = new RegExp(
   "^-----BEGIN [A-Z\x20]{1,48}-----([^-]*)-----END [A-Z\x20]{1,48}-----$",
   "s",
 );
@@ -111,7 +111,7 @@ export const EXTRACT_X509_CERTS = new RegExp(
   "-----BEGIN CERTIFICATE-----[^-]*-----END CERTIFICATE-----",
   "g",
 );
-export const BASE64_REGEX = new RegExp(
+const BASE64_REGEX = new RegExp(
   "^(?:[A-Za-z0-9\\+\\/]{4}\\n{0,1})*(?:[A-Za-z0-9\\+\\/]{2}==|[A-Za-z0-9\\+\\/]{3}=)?$",
   "s",
 );

--- a/test/public-api-tests.spec.ts
+++ b/test/public-api-tests.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from "chai";
+import * as xmlCrypto from "../src/index";
+
+/**
+ * The published surface used to grow by accident: `index.ts` re-exported `./utils` with
+ * `export *`, so adding a helper for `signed-xml.ts` to use published it too. The list is
+ * explicit now, and this test makes widening it a deliberate edit rather than a side effect.
+ *
+ * Only runtime values can be checked here — types are erased, but they can only reach the
+ * surface by being named in `index.ts`, which is a reviewable diff on its own.
+ *
+ * @see https://github.com/node-saml/xml-crypto/issues/551
+ */
+const PUBLIC_EXPORTS = [
+  "C14nCanonicalization",
+  "C14nCanonicalizationWithComments",
+  "ExclusiveCanonicalization",
+  "ExclusiveCanonicalizationWithComments",
+  "SignedXml",
+  "createOptionalCallbackFunction",
+  "derToPem",
+  "findAncestorNs",
+  "normalizePem",
+  "pemToDer",
+];
+
+describe("Public API surface", function () {
+  it("exports exactly the documented names", function () {
+    expect(Object.keys(xmlCrypto).sort()).to.deep.equal(PUBLIC_EXPORTS);
+  });
+
+  /**
+   * `index.ts` only decides what the barrel re-exports. Without an `exports` map every file
+   * under `lib/` is reachable by path too, and consumers do reach for it, so the entry points
+   * are pinned here as well.
+   */
+  it("declares only the package entry point and package.json as subpaths", function () {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const manifest = require("../package.json");
+
+    expect(Object.keys(manifest.exports)).to.deep.equal([".", "./package.json"]);
+    expect(manifest.exports["."]).to.deep.equal({
+      types: "./lib/index.d.ts",
+      default: "./lib/index.js",
+    });
+  });
+});


### PR DESCRIPTION
Closes #551

`index.ts` did `export * from "./utils"`, so every helper written for `signed-xml.ts` to use became public API at the same time. That is how `findChilds` stayed published with no callers, and how each new helper joined the surface without anyone choosing to publish it.

The keep list is informed by the [consumer survey](https://github.com/node-saml/xml-crypto/issues/551#issuecomment-5609303224) on the issue, which checked what dependents and public code actually import rather than what we call.

## What stays

| Export | Why |
| --- | --- |
| `derToPem`, `pemToDer`, `normalizePem` | key-format conversion is a real consumer need; `pemToDer` has a confirmed importer, and three separate projects hand-rolled a `normalizePem`, which says the need is real and the export merely undiscoverable |
| `findAncestorNs` | already part of the custom-canonicalization contract in practice — `akira-io/node-efatura`, `kacheablecr-jpg/nervus-backend` and `dressoria/sri-signing-worker` all `import { C14nCanonicalization, findAncestorNs } from "xml-crypto"` |

## What goes

`findAttr`, `findChildren`, `findChilds`, `isDescendantOf`, `isArrayHasLength`, `encodeSpecialCharactersInAttribute`, `encodeSpecialCharactersInText`, `validateDigestValue`, `BASE64_REGEX`, `EXTRACT_X509_CERTS`, `PEM_FORMAT_REGEX`. None has a confirmed importer; every code-search hit was a same-named local helper, a fork, a vendored copy, or a CVE-reproduction corpus.

`validateDigestValue` goes internal despite the issue's "check before dropping" note. Nobody imports it, so the risk of pushing someone toward a naive `===` is not realised — and publishing the constant-time comparison is itself what invites reimplementation. It belongs behind the API that already uses it.

`BASE64_REGEX` and `PEM_FORMAT_REGEX` lose the `export` keyword outright since no sibling uses them. The rest stay exported from `utils.ts` for their siblings but are no longer re-exported to consumers — a sibling and a consumer reaching a helper through the same `export` keyword is the root cause, and `index.ts` is now the only place that can widen the surface.

## `lib/` was public too

`index.ts` only governs the barrel. With no `exports` map, every file under `lib/` was reachable by path, and consumers do reach: `shunkica/fiskalizacija2-js` does

```ts
import { Sha256 } from "xml-crypto/lib/hash-algorithms.js";
```

for a class we never exported. So `package.json` now declares an `exports` map naming the entry point and `package.json` and nothing else. Verified against a real package resolution: the barrel resolves, `xml-crypto/lib/hash-algorithms.js` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`, `xml-crypto/package.json` still resolves. `main` and `types` stay for resolvers that ignore `exports`.

The bundled algorithm classes remain reachable through the registries that name them, which the README now documents:

```js
const Sha256 = new SignedXml().HashAlgorithms["http://www.w3.org/2001/04/xmlenc#sha256"];
```

## Guard against regrowth

`test/public-api-tests.spec.ts` pins both the runtime export names and the declared subpaths, so widening either shows up as a reviewable diff rather than a side effect of adding a helper or a file. Confirmed it fails on `master`, listing exactly the names withdrawn here.

## README fix found along the way

The README documented an `xpath` export that 6.x does not have — `require("xml-crypto").xpath` is `undefined`, so the verification example would have thrown on `select(...)`. The examples now use the `xpath` package directly, whose `select()` takes the expression first; verified the corrected example validates `test/static/valid_signature.xml`. That section is replaced with the actual export list.

## Ordering

#559 deprecates every name withdrawn here, with a runtime warning, and is meant to land on 6.x first. This branch will need a rebase after that.

## Verification

`npm run build && npm test && npm run lint` clean; 243 passing (241 + 2).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
