### PR TITLE
test: pin the hoisted ancestor namespace behaviour #541 fixed

### DIFF
--- a/test/c14n-non-exclusive-unit-tests.spec.ts
+++ b/test/c14n-non-exclusive-unit-tests.spec.ts
@@ -250,6 +250,70 @@ describe("C14N non-exclusive canonicalization tests", function () {
   });
 
   for (const Canonicalization of [C14nCanonicalization, C14nCanonicalizationWithComments]) {
+    describe(`${Canonicalization.name}: hoisted ancestor namespaces`, function () {
+      // A hoisted ancestor default namespace becomes the default the subset's descendants are
+      // canonicalized against. The rationale is spelled out in §4.7: the empty default is kept on
+      // output "so that e3 does not take on the default namespace qualification of e1".
+      // https://www.w3.org/TR/xml-c14n/#ProcessingModel
+      // https://www.w3.org/TR/xml-c14n/#PropagateDefaultNSDecl
+      it('renders xmlns="" on a descendant when the apex hoists an ancestor default namespace', function () {
+        test_C14nCanonicalization(
+          '<root xmlns="urn:A"><p:x xmlns:p="urn:p"><y xmlns=""></y></p:x></root>',
+          "//*[local-name()='x']",
+          '<p:x xmlns="urn:A" xmlns:p="urn:p"><y xmlns=""></y></p:x>',
+          new Canonicalization(),
+        );
+      });
+
+      it("omits a descendant declaration the hoisted ancestor default namespace makes redundant", function () {
+        test_C14nCanonicalization(
+          '<root xmlns="urn:A"><p:x xmlns:p="urn:p"><y xmlns="urn:A"></y></p:x></root>',
+          "//*[local-name()='x']",
+          '<p:x xmlns="urn:A" xmlns:p="urn:p"><y></y></p:x>',
+          new Canonicalization(),
+        );
+      });
+
+      it("renders the hoisted ancestor default namespace once when the apex inherits it", function () {
+        test_C14nCanonicalization(
+          '<root xmlns="urn:A"><x xmlns:p="urn:p"><y xmlns=""></y></x></root>',
+          "//*[local-name()='x']",
+          '<x xmlns="urn:A" xmlns:p="urn:p"><y xmlns=""></y></x>',
+          new Canonicalization(),
+        );
+      });
+
+      it("prefers the apex's own default namespace over the hoisted ancestor one", function () {
+        test_C14nCanonicalization(
+          '<root xmlns="urn:A"><x xmlns:p="urn:p" xmlns="urn:B"><y></y></x></root>',
+          "//*[local-name()='x']",
+          '<x xmlns="urn:B" xmlns:p="urn:p"><y></y></x>',
+          new Canonicalization(),
+        );
+      });
+
+      // A declaration on the apex shadows the ancestor one binding the same prefix, so the
+      // element must not resolve against the outer binding — in its descendants or its own name.
+      // https://www.w3.org/TR/REC-xml-names/#scoping
+      it("renders the apex's redeclaration of an ancestor prefix, not the ancestor binding", function () {
+        test_C14nCanonicalization(
+          '<root xmlns:q="urn:old"><x xmlns:p="urn:p" xmlns:q="urn:new"><q:y></q:y></x></root>',
+          "//*[local-name()='x']",
+          '<x xmlns:p="urn:p" xmlns:q="urn:new"><q:y></q:y></x>',
+          new Canonicalization(),
+        );
+      });
+
+      it("renders the apex's redeclaration of the prefix in its own name", function () {
+        test_C14nCanonicalization(
+          '<root xmlns:q="urn:old"><q:x xmlns:p="urn:p" xmlns:q="urn:new"><y></y></q:x></root>',
+          "//*[local-name()='x']",
+          '<q:x xmlns:p="urn:p" xmlns:q="urn:new"><y></y></q:x>',
+          new Canonicalization(),
+        );
+      });
+    });
+
     describe(`${Canonicalization.name}: subset namespace declarations`, function () {
       it("does not duplicate the default namespace when the subset declares a prefixed namespace", function () {
         // Render the inherited default namespace exactly once on the subset root.

--- a/test/signature-integration-tests.spec.ts
+++ b/test/signature-integration-tests.spec.ts
@@ -341,4 +341,42 @@ describe("Signature integration tests", function () {
       });
     });
   }
+
+  // A signed reference must hand back the element in the namespace it was signed in. If a
+  // hoisted ancestor default namespace leaks into a descendant, the signature still verifies
+  // while `getSignedReferences()` reports an identity the sender never signed — and a caller
+  // that dispatches on element namespace acts on it.
+  // https://www.w3.org/TR/xml-c14n/#ProcessingModel
+  it("does not move an element into a namespace it was not signed in", function () {
+    const c14n = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+    const xml = '<root xmlns="urn:A"><p:x xmlns:p="urn:p" Id="_1"><y xmlns=""></y></p:x></root>';
+
+    const sig = new SignedXml();
+    sig.privateKey = fs.readFileSync("./test/static/client.pem");
+    sig.canonicalizationAlgorithm = c14n;
+    sig.signatureAlgorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+    sig.addReference({
+      xpath: "//*[local-name(.)='x']",
+      digestAlgorithm: "http://www.w3.org/2000/09/xmldsig#sha1",
+      transforms: [c14n],
+    });
+    sig.computeSignature(xml);
+    const signed = sig.getSignedXml();
+
+    const signature = xpath.select1(
+      "//*[local-name(.)='Signature']",
+      new xmldom.DOMParser().parseFromString(signed),
+    );
+    isDomNode.assertIsNodeLike(signature);
+
+    const verify = new SignedXml();
+    verify.publicCert = fs.readFileSync("./test/static/client_public.pem");
+    verify.loadSignature(signature);
+    expect(verify.checkSignature(signed)).to.be.true;
+
+    const trusted = new xmldom.DOMParser().parseFromString(verify.getSignedReferences()[0]);
+    const y = xpath.select1("//*[local-name(.)='y']", trusted);
+    isDomNode.assertIsElementNode(y);
+    expect(y.namespaceURI ?? "", "<y> must stay in no namespace").to.equal("");
+  });
 });


### PR DESCRIPTION
Refs #538, #541.

Three branches were open against defects in the ancestor-namespace path of non-exclusive C14N:

1. a hoisted ancestor default namespace not becoming the default its descendants were canonicalized against, so a child's own `xmlns=""` read as redundant and was dropped;
2. an ancestor declaration being appended alongside one the node made itself, producing two `xmlns` attributes on one element;
3. `process()` marking ancestor prefixes in scope before anything had been rendered, so the apex's own redeclaration of such a prefix was skipped as redundant and resolved to the outer binding.

**All three are already fixed on `master`.** #541 got there by a different route — `localDefaultNs`/`nodeDefaultNs` in `renderNs`, `newDefaultNs` seeded from the hoisted entry in the ancestor merge, and `findSubsetNSPrefixes` collecting every prefix the subset declares rather than the first. So the fixes those branches carried are obsolete and are dropped.

Their tests are not obsolete. `master` satisfies these spec requirements without asserting any of them, in an area that has now produced four separate defects.

## These are guards, not documentation

Each of the six unit cases fails against `src/c14n-canonicalization.ts` as it stood before #541 and passes on `master`. Two spot checks confirm they bite against plausible regressions:

| Perturbation of `master` | Failures |
| --- | --- |
| drop `newDefaultNs = ancestorNamespace.namespaceURI` from the ancestor merge | 7 (4 without this PR) |
| revert `findSubsetNSPrefixes` to the first declaration only | 12 (11 without this PR) |

The cases are parameterized over both `C14nCanonicalization` and `C14nCanonicalizationWithComments`, which the original branches did not do.

## The integration case

The one worth having. A hoisted default namespace leaking into a descendant leaves the signature verifying while `getSignedReferences()` — the API the README designates as the secure replacement for `getValidatedNode()` — reports the element in a namespace the sender never signed it in. A caller that dispatches on element namespace then acts on an identity that was never signed, and the sender picks it. Nothing else in the suite covers that.

Cited inline: C14N 1.0 [§2.3](https://www.w3.org/TR/xml-c14n/#ProcessingModel), the [§4.7](https://www.w3.org/TR/xml-c14n/#PropagateDefaultNSDecl) rationale for preserving `xmlns=""`, and [Namespaces in XML §2.2](https://www.w3.org/TR/REC-xml-names/#scoping) for prefix scoping.

## Milestone

v6.2, matching #541 — test-only, no behaviour change.

## Verification

`npm run build && npm test && npm run lint` clean; 254 passing (241 + 13; 6 cases × 2 canonicalizers + 1 integration).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
