### PR TITLE
feat!: remove deprecated findChilds() alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@
 
 ## Upgrading
 
+### Upgrading to 7.0
+
+`findChilds()` has been removed. It was a deprecated alias that only ever forwarded to
+`findChildren()`, which has an identical signature and behaviour:
+
+```js
+// before
+findChilds(node, localName, namespace);
+// after
+findChildren(node, localName, namespace);
+```
+
+### Upgrading to 6.0
+
 The `.getReferences()` AND the `.references` APIs are deprecated.
 Please do not attempt to access them. The content in them should be treated as unsigned.
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,11 +47,6 @@ export function findChildren(node: Node | Document, localName: string, namespace
   return res;
 }
 
-/** @deprecated */
-export function findChilds(node: Node | Document, localName: string, namespace?: string) {
-  return findChildren(node, localName, namespace);
-}
-
 const xml_special_to_encoded_attribute = {
   "&": "&amp;",
   "<": "&lt;",


### PR DESCRIPTION
Closes #550

`findChilds` was renamed to `findChildren` in #363 and has had no internal callers since. It survived only because `src/index.ts` re-exported it via `export * from "./utils"`, which published the name without anyone choosing to. Nothing in `src/` or `test/` referenced it.

## Migration

`findChilds(node, localName, namespace)` → `findChildren(node, localName, namespace)`. Identical signature and behaviour; the alias only ever forwarded. Recorded in the README `Upgrading` section.

## On the deprecation warning first

The issue asks whether this needs a runtime warning in a 6.x release before the name disappears — it does. `findChilds` carried a bare `/** @deprecated */` with no replacement named and no runtime signal, so a JavaScript consumer got nothing at all. That half is in #567, which is meant to ship on 6.x before `master` rolls over to 7.x.

## Verification

`npm run build && npm test && npm run lint` clean; 241 passing, unchanged from `master`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
