### PR TITLE
feat!: decouple public key and data types from node:crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@
 
 ## Upgrading
 
+### Upgrading to 7.0
+
+Key material and data types no longer name `node:crypto` in the public API. `privateKey`,
+`publicCert` and the `SignatureAlgorithm` key arguments are now `KeyLike`, and the data to
+be signed is `BinaryLike`; both are exported from this package.
+
+This is source-compatible for callers. It is a break for anyone who **implements**
+`SignatureAlgorithm`: the interface now takes the accepted key type as a parameter, so an
+implementation should declare it — `implements SignatureAlgorithm<crypto.KeyLike>` for a
+`node:crypto`-backed one. See
+[declaring the key material your algorithm accepts](#declaring-the-key-material-your-algorithm-accepts).
+
+The bundled algorithms now throw when handed key material `node:crypto` cannot use, instead
+of letting a `CryptoKey` through Node's DEP0203 shim as if it were supported.
+
+### Upgrading to 6.0
+
 The `.getReferences()` AND the `.references` APIs are deprecated.
 Please do not attempt to access them. The content in them should be treated as unsigned.
 
@@ -61,8 +78,8 @@ signature algorithms enabled at same time.
 
 When signing a xml document you can pass the following options to the `SignedXml` constructor to customize the signature process:
 
-- `privateKey` - **[required]** a `Buffer` or pem encoded `String` containing your private key
-- `publicCert` - **[optional]** a `Buffer` or pem encoded `String` containing your public key
+- `privateKey` - **[required]** your private key, as a pem encoded `String`, a `Buffer`, a `Uint8Array`, or a `KeyObject`. Typed [`KeyLike`](#declaring-the-key-material-your-algorithm-accepts), which is wider than any one algorithm accepts
+- `publicCert` - **[optional]** your public certificate, in the same forms
 - `signatureAlgorithm` - **[required]** one of the supported [signature algorithms](#signature-algorithms). Ex: `sign.signatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"`
 - `canonicalizationAlgorithm` - **[required]** one of the supported [canonicalization algorithms](#canonicalization-and-transformation-algorithms). Ex: `sign.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"`
 
@@ -138,6 +155,8 @@ When verifying a xml document you can pass the following options to the `SignedX
 
 - `publicCert` - **[optional]** your certificate as a string, a string of multiple certs in PEM format, or a Buffer
 - `privateKey` - **[optional]** your private key as a string or a Buffer - used for verifying symmetrical signatures (HMAC)
+
+Both are typed [`KeyLike`](#declaring-the-key-material-your-algorithm-accepts).
 
 The certificate that will be used to check the signature will first be determined by calling `this.getCertFromKeyInfo()`, which function you can customize as you see fit. If that returns `null`, then `publicCert` is used. If that is `null`, then `privateKey` is used (for symmetrical signing applications).
 
@@ -249,8 +268,8 @@ The `SignedXml` constructor provides an abstraction for sign and verify xml docu
 
 - `idMode` - default `null` - if the value of `wssecurity` is passed it will create/validate id's with the ws-security namespace.
 - `idAttribute` - string - default `Id` or `ID` or `id` - the name of the attribute that contains the id of the element
-- `privateKey` - string or Buffer - default `null` - the private key to use for signing
-- `publicCert` - string or Buffer - default `null` - the public certificate to use for verifying
+- `privateKey` - [`KeyLike`](#declaring-the-key-material-your-algorithm-accepts) - default `null` - the private key to use for signing
+- `publicCert` - [`KeyLike`](#declaring-the-key-material-your-algorithm-accepts) - default `null` - the public certificate to use for verifying
 - `signatureAlgorithm` - string - the signature algorithm to use
 - `canonicalizationAlgorithm` - string - default `undefined` - the canonicalization algorithm to use
 - `inclusiveNamespacesPrefixList` - string - default `null` - a list of namespace prefixes to include during canonicalization
@@ -337,6 +356,44 @@ function MySignatureAlgorithm() {
   };
 }
 ```
+
+#### Declaring the key material your algorithm accepts
+
+`privateKey`, `publicCert` and the key arguments to `SignatureAlgorithm` are typed as
+`KeyLike`, which is the widest set the library can carry:
+
+```ts
+type KeyLike = crypto.KeyLike | crypto.webcrypto.CryptoKey | Uint8Array;
+```
+
+That is deliberately wider than any single algorithm can use. `CryptoKey` is the only key
+representation the Web Crypto API produces, so it has to be nameable — but nothing built on
+`node:crypto` can use one. So `SignatureAlgorithm` takes the key type as a parameter, and an
+implementation declares the subset it actually accepts:
+
+```ts
+import * as crypto from "crypto";
+import type { BinaryLike, SignatureAlgorithm } from "xml-crypto";
+
+class MySignatureAlgorithm implements SignatureAlgorithm<crypto.KeyLike> {
+  getSignature = (signedInfo: BinaryLike, privateKey: crypto.KeyLike): string => {
+    // `privateKey` is narrowed to what node:crypto takes — no cast needed.
+  };
+
+  getAlgorithmName = () => "http://mySigningAlgorithm";
+}
+```
+
+Declare the narrowest type that works rather than leaving it at `KeyLike`. Leaving it wide
+compiles, but it advertises support the implementation does not have, and callers get no
+diagnostic when they pair your algorithm with a key it cannot use. Handed a `CryptoKey`,
+`node:crypto` does not fail — it accepts it through the
+[DEP0203](https://nodejs.org/api/deprecations.html#DEP0203) shim, so a signature appears to
+verify against a key the algorithm never really supported. The bundled algorithms reject
+non-Node key material with an explicit error for that reason.
+
+`signedInfo` is typed `BinaryLike` (`crypto.BinaryLike | ArrayBuffer`). `node:crypto` accepts
+every arm except a bare `ArrayBuffer`, which `Buffer.from(data)` views without copying.
 
 Custom transformation algorithm.
 
@@ -451,7 +508,7 @@ The function `sig.checkSignature` may also use a callback if asynchronous verifi
 
 ## X.509 / Key formats
 
-Xml-Crypto internally relies on node's crypto module. This means pem encoded certificates are supported. So to sign an xml use key.pem that looks like this (only the beginning of the key content is shown):
+The bundled algorithms are backed by node's crypto module, so pem encoded certificates are supported. To sign an xml use key.pem that looks like this (only the beginning of the key content is shown):
 
 ```text
 -----BEGIN PRIVATE KEY-----

--- a/src/signature-algorithms.ts
+++ b/src/signature-algorithms.ts
@@ -1,22 +1,58 @@
 import * as crypto from "crypto";
-import { type SignatureAlgorithm, createOptionalCallbackFunction } from "./types";
+import {
+  type BinaryLike,
+  type KeyLike,
+  type SignatureAlgorithm,
+  createOptionalCallbackFunction,
+} from "./types";
 
-export class RsaSha1 implements SignatureAlgorithm {
+/**
+ * `node:crypto` takes any `ArrayBufferView` but not a bare `ArrayBuffer`, which is what Web
+ * Crypto produces. Wrap rather than copy: `Buffer.from` over the three arguments is a view.
+ */
+function toNodeData(data: BinaryLike): crypto.BinaryLike {
+  return data instanceof ArrayBuffer ? Buffer.from(data) : data;
+}
+
+/**
+ * The signature algorithm is looked up by a URI read from the document under inspection, so a
+ * JavaScript caller can pair any key representation with any algorithm and the compiler never
+ * sees it. Handed a `CryptoKey`, Node does not fail: it accepts it through the DEP0203 shim,
+ * so the signature appears to verify against a key this algorithm never really supported.
+ * Reject it here instead.
+ *
+ * @see https://github.com/node-saml/xml-crypto/issues/545
+ */
+function toNodeKey(key: KeyLike, algorithmName: string): crypto.KeyLike {
+  if (typeof key === "string" || Buffer.isBuffer(key) || key instanceof crypto.KeyObject) {
+    return key;
+  }
+
+  if (key instanceof Uint8Array) {
+    return Buffer.from(key.buffer, key.byteOffset, key.byteLength);
+  }
+
+  throw new Error(
+    `${algorithmName} needs a key that node:crypto accepts: a string, a Buffer, a Uint8Array, or a KeyObject`,
+  );
+}
+
+export class RsaSha1 implements SignatureAlgorithm<crypto.KeyLike | Uint8Array> {
   getSignature = createOptionalCallbackFunction(
-    (signedInfo: crypto.BinaryLike, privateKey: crypto.KeyLike): string => {
+    (signedInfo: BinaryLike, privateKey: crypto.KeyLike | Uint8Array): string => {
       const signer = crypto.createSign("RSA-SHA1");
-      signer.update(signedInfo);
-      const res = signer.sign(privateKey, "base64");
+      signer.update(toNodeData(signedInfo));
+      const res = signer.sign(toNodeKey(privateKey, "RsaSha1"), "base64");
 
       return res;
     },
   );
 
   verifySignature = createOptionalCallbackFunction(
-    (material: string, key: crypto.KeyLike, signatureValue: string): boolean => {
+    (material: string, key: crypto.KeyLike | Uint8Array, signatureValue: string): boolean => {
       const verifier = crypto.createVerify("RSA-SHA1");
       verifier.update(material);
-      const res = verifier.verify(key, signatureValue, "base64");
+      const res = verifier.verify(toNodeKey(key, "RsaSha1"), signatureValue, "base64");
 
       return res;
     },
@@ -27,22 +63,22 @@ export class RsaSha1 implements SignatureAlgorithm {
   };
 }
 
-export class RsaSha256 implements SignatureAlgorithm {
+export class RsaSha256 implements SignatureAlgorithm<crypto.KeyLike | Uint8Array> {
   getSignature = createOptionalCallbackFunction(
-    (signedInfo: crypto.BinaryLike, privateKey: crypto.KeyLike): string => {
+    (signedInfo: BinaryLike, privateKey: crypto.KeyLike | Uint8Array): string => {
       const signer = crypto.createSign("RSA-SHA256");
-      signer.update(signedInfo);
-      const res = signer.sign(privateKey, "base64");
+      signer.update(toNodeData(signedInfo));
+      const res = signer.sign(toNodeKey(privateKey, "RsaSha256"), "base64");
 
       return res;
     },
   );
 
   verifySignature = createOptionalCallbackFunction(
-    (material: string, key: crypto.KeyLike, signatureValue: string): boolean => {
+    (material: string, key: crypto.KeyLike | Uint8Array, signatureValue: string): boolean => {
       const verifier = crypto.createVerify("RSA-SHA256");
       verifier.update(material);
-      const res = verifier.verify(key, signatureValue, "base64");
+      const res = verifier.verify(toNodeKey(key, "RsaSha256"), signatureValue, "base64");
 
       return res;
     },
@@ -53,14 +89,14 @@ export class RsaSha256 implements SignatureAlgorithm {
   };
 }
 
-export class RsaSha256Mgf1 implements SignatureAlgorithm {
+export class RsaSha256Mgf1 implements SignatureAlgorithm<string | Buffer> {
   getSignature = createOptionalCallbackFunction(
-    (signedInfo: crypto.BinaryLike, privateKey: crypto.KeyLike): string => {
+    (signedInfo: BinaryLike, privateKey: string | Buffer): string => {
       if (!(typeof privateKey === "string" || Buffer.isBuffer(privateKey))) {
         throw new Error("keys must be strings or buffers");
       }
       const signer = crypto.createSign("RSA-SHA256");
-      signer.update(signedInfo);
+      signer.update(toNodeData(signedInfo));
       const res = signer.sign(
         {
           key: privateKey,
@@ -75,7 +111,7 @@ export class RsaSha256Mgf1 implements SignatureAlgorithm {
   );
 
   verifySignature = createOptionalCallbackFunction(
-    (material: string, key: crypto.KeyLike, signatureValue: string): boolean => {
+    (material: string, key: string | Buffer, signatureValue: string): boolean => {
       if (!(typeof key === "string" || Buffer.isBuffer(key))) {
         throw new Error("keys must be strings or buffers");
       }
@@ -100,22 +136,22 @@ export class RsaSha256Mgf1 implements SignatureAlgorithm {
   };
 }
 
-export class RsaSha512 implements SignatureAlgorithm {
+export class RsaSha512 implements SignatureAlgorithm<crypto.KeyLike | Uint8Array> {
   getSignature = createOptionalCallbackFunction(
-    (signedInfo: crypto.BinaryLike, privateKey: crypto.KeyLike): string => {
+    (signedInfo: BinaryLike, privateKey: crypto.KeyLike | Uint8Array): string => {
       const signer = crypto.createSign("RSA-SHA512");
-      signer.update(signedInfo);
-      const res = signer.sign(privateKey, "base64");
+      signer.update(toNodeData(signedInfo));
+      const res = signer.sign(toNodeKey(privateKey, "RsaSha512"), "base64");
 
       return res;
     },
   );
 
   verifySignature = createOptionalCallbackFunction(
-    (material: string, key: crypto.KeyLike, signatureValue: string): boolean => {
+    (material: string, key: crypto.KeyLike | Uint8Array, signatureValue: string): boolean => {
       const verifier = crypto.createVerify("RSA-SHA512");
       verifier.update(material);
-      const res = verifier.verify(key, signatureValue, "base64");
+      const res = verifier.verify(toNodeKey(key, "RsaSha512"), signatureValue, "base64");
 
       return res;
     },
@@ -126,11 +162,11 @@ export class RsaSha512 implements SignatureAlgorithm {
   };
 }
 
-export class HmacSha1 implements SignatureAlgorithm {
+export class HmacSha1 implements SignatureAlgorithm<crypto.KeyLike | Uint8Array> {
   getSignature = createOptionalCallbackFunction(
-    (signedInfo: crypto.BinaryLike, privateKey: crypto.KeyLike): string => {
-      const signer = crypto.createHmac("SHA1", privateKey);
-      signer.update(signedInfo);
+    (signedInfo: BinaryLike, privateKey: crypto.KeyLike | Uint8Array): string => {
+      const signer = crypto.createHmac("SHA1", toNodeKey(privateKey, "HmacSha1"));
+      signer.update(toNodeData(signedInfo));
       const res = signer.digest("base64");
 
       return res;
@@ -138,8 +174,8 @@ export class HmacSha1 implements SignatureAlgorithm {
   );
 
   verifySignature = createOptionalCallbackFunction(
-    (material: string, key: crypto.KeyLike, signatureValue: string): boolean => {
-      const verifier = crypto.createHmac("SHA1", key);
+    (material: string, key: crypto.KeyLike | Uint8Array, signatureValue: string): boolean => {
+      const verifier = crypto.createHmac("SHA1", toNodeKey(key, "HmacSha1"));
       verifier.update(material);
       const res = verifier.digest("base64");
 

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -8,6 +8,7 @@ import type {
   GetKeyInfoContentArgs,
   HashAlgorithm,
   HashAlgorithmType,
+  KeyLike,
   ObjectAttributes,
   Reference,
   SignatureAlgorithm,
@@ -17,7 +18,6 @@ import type {
 
 import * as isDomNode from "@xmldom/is-dom-node";
 import * as xmldom from "@xmldom/xmldom";
-import * as crypto from "crypto";
 import { deprecate } from "util";
 import * as xpath from "xpath";
 import * as c14n from "./c14n-canonicalization";
@@ -39,8 +39,8 @@ export class SignedXml {
   /**
    * A {@link Buffer} or pem encoded {@link String} containing your private key
    */
-  privateKey?: crypto.KeyLike;
-  publicCert?: crypto.KeyLike;
+  privateKey?: KeyLike;
+  publicCert?: KeyLike;
   /**
    * One of the supported signature algorithms.
    * @see {@link SignatureAlgorithmType}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,28 @@ import * as crypto from "crypto";
 
 export type ErrorFirstCallback<T> = (err: Error | null, result?: T) => void;
 
+/**
+ * Data that can be signed or verified, expressed without assuming a Node runtime.
+ *
+ * `node:crypto` accepts a string or any `ArrayBufferView`. A bare `ArrayBuffer` is included
+ * here because that is what the Web Crypto API produces; an implementation that ends up in
+ * `node:crypto` has to view it as a `Buffer` first.
+ */
+export type BinaryLike = crypto.BinaryLike | ArrayBuffer;
+
+/**
+ * Key material a {@link SignatureAlgorithm} may accept, expressed without assuming a Node
+ * runtime. `CryptoKey` is the only key representation the Web Crypto API produces, so it has
+ * to be nameable here even though no bundled algorithm can use one.
+ *
+ * This is the widest set, not a promise that any given algorithm handles all of it. An
+ * implementation declares the subset it can actually use — see {@link SignatureAlgorithm}.
+ *
+ * The Web Crypto type is spelled `crypto.webcrypto.CryptoKey` so that it resolves without
+ * `lib.dom`; a global or DOM `CryptoKey` is structurally identical and assignable to it.
+ */
+export type KeyLike = crypto.KeyLike | crypto.webcrypto.CryptoKey | Uint8Array;
+
 export type CanonicalizationAlgorithmType =
   | "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
   | "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"
@@ -39,7 +61,7 @@ export type SignatureAlgorithmType =
  * @param prefix an optional namespace alias to be used for the generated XML
  */
 export interface GetKeyInfoContentArgs {
-  publicCert?: crypto.KeyLike;
+  publicCert?: KeyLike;
   prefix?: string | null;
 }
 
@@ -64,8 +86,8 @@ export interface ObjectAttributes {
 export interface SignedXmlOptions {
   idMode?: "wssecurity";
   idAttribute?: string;
-  privateKey?: crypto.KeyLike;
-  publicCert?: crypto.KeyLike;
+  privateKey?: KeyLike;
+  publicCert?: KeyLike;
   signatureAlgorithm?: SignatureAlgorithmType;
   canonicalizationAlgorithm?: CanonicalizationAlgorithmType;
   inclusiveNamespacesPrefixList?: string | string[];
@@ -176,15 +198,23 @@ export interface HashAlgorithm {
   getHash(xml: string): string;
 }
 
-/** Extend this to create a new SignatureAlgorithm */
-export interface SignatureAlgorithm {
+/**
+ * Extend this to create a new SignatureAlgorithm.
+ *
+ * `TKey` is the key material the implementation accepts. Declare the narrowest type that
+ * actually works rather than leaving it at {@link KeyLike}: a `node:crypto`-backed algorithm
+ * cannot use a Web Crypto `CryptoKey`, and saying `KeyLike` would claim that it can.
+ *
+ * @see https://github.com/node-saml/xml-crypto/issues/545
+ */
+export interface SignatureAlgorithm<TKey extends KeyLike = KeyLike> {
   /**
    * Sign the given string using the given key
    */
-  getSignature(signedInfo: crypto.BinaryLike, privateKey: crypto.KeyLike): string;
+  getSignature(signedInfo: BinaryLike, privateKey: TKey): string;
   getSignature(
-    signedInfo: crypto.BinaryLike,
-    privateKey: crypto.KeyLike,
+    signedInfo: BinaryLike,
+    privateKey: TKey,
     callback?: ErrorFirstCallback<string>,
   ): void;
   /**
@@ -192,10 +222,10 @@ export interface SignatureAlgorithm {
    *
    * @param key a public cert, public key, or private key can be passed here
    */
-  verifySignature(material: string, key: crypto.KeyLike, signatureValue: string): boolean;
+  verifySignature(material: string, key: TKey, signatureValue: string): boolean;
   verifySignature(
     material: string,
-    key: crypto.KeyLike,
+    key: TKey,
     signatureValue: string,
     callback?: ErrorFirstCallback<boolean>,
   ): void;

--- a/test/key-material-tests.spec.ts
+++ b/test/key-material-tests.spec.ts
@@ -1,0 +1,79 @@
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as xmldom from "@xmldom/xmldom";
+import * as xpath from "xpath";
+import * as isDomNode from "@xmldom/is-dom-node";
+import { expect } from "chai";
+import { SignedXml, pemToDer } from "../src/index";
+
+const RSA_SHA256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+
+function signerFor(privateKey: crypto.KeyLike | Uint8Array): SignedXml {
+  const sig = new SignedXml();
+  sig.privateKey = privateKey;
+  sig.canonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#";
+  sig.signatureAlgorithm = RSA_SHA256;
+  sig.addReference({
+    xpath: "//*[local-name(.)='x']",
+    digestAlgorithm: "http://www.w3.org/2001/04/xmlenc#sha256",
+    transforms: ["http://www.w3.org/2001/10/xml-exc-c14n#"],
+  });
+  return sig;
+}
+
+function verify(signedXml: string): boolean {
+  const doc = new xmldom.DOMParser().parseFromString(signedXml);
+  const node = xpath.select1(
+    "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']",
+    doc,
+  );
+  isDomNode.assertIsNodeLike(node);
+  const sig = new SignedXml();
+  sig.publicCert = fs.readFileSync("./test/static/client_public.pem");
+  sig.loadSignature(node);
+  return sig.checkSignature(signedXml);
+}
+
+describe("Key material accepted by the bundled algorithms", function () {
+  const xml = '<root><x attr="value"></x></root>';
+
+  it("signs and verifies with a private key given as a Uint8Array", function () {
+    const pem = fs.readFileSync("./test/static/client.pem");
+    const sig = signerFor(new Uint8Array(pem));
+    sig.computeSignature(xml);
+
+    expect(verify(sig.getSignedXml())).to.be.true;
+  });
+
+  it("refuses a Web Crypto key rather than signing through the DEP0203 shim", async function () {
+    const cryptoKey = await crypto.webcrypto.subtle.importKey(
+      "pkcs8",
+      pemToDer(fs.readFileSync("./test/static/client.pem", "latin1")),
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+
+    // Node accepts a CryptoKey here and only emits a deprecation warning, so the signature
+    // would look valid until the shim is removed and would never work off-Node.
+    // https://github.com/node-saml/xml-crypto/issues/545
+    const sig = signerFor(cryptoKey as unknown as crypto.KeyLike);
+
+    expect(() => sig.computeSignature(xml)).to.throw(/RsaSha256 needs a key that node:crypto/);
+  });
+
+  it("signs an ArrayBuffer identically to the equivalent string", function () {
+    const signatureAlgorithms = new SignedXml().SignatureAlgorithms;
+    const algorithm = new signatureAlgorithms[RSA_SHA256]();
+    const privateKey = fs.readFileSync("./test/static/client.pem");
+    const signedInfo = "<SignedInfo></SignedInfo>";
+    const bytes = Buffer.from(signedInfo, "utf8");
+
+    expect(
+      algorithm.getSignature(
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+        privateKey,
+      ),
+    ).to.equal(algorithm.getSignature(signedInfo, privateKey));
+  });
+});


### PR DESCRIPTION
Closes #545

Every public signature that touched key material named `node:crypto` directly, which hard-coded Node into the type surface: a caller could not pass a `CryptoKey` — the only key representation Web Crypto produces — so the types blocked a Web Crypto backend before any implementation existed.

`BinaryLike` and `KeyLike` are now defined in `src/types.ts` and used for `SignedXmlOptions.privateKey`/`publicCert`, `GetKeyInfoContentArgs.publicCert` and the `SignatureAlgorithm` interface.

## How the bundled algorithms narrow, without blanket casts

The issue offers three options; this takes the first. `SignatureAlgorithm` takes the accepted key type as a parameter, so each implementation states what it can really use:

| Algorithm | Declares |
| --- | --- |
| `RsaSha1`, `RsaSha256`, `RsaSha512`, `HmacSha1` | `SignatureAlgorithm<crypto.KeyLike \| Uint8Array>` |
| `RsaSha256Mgf1` | `SignatureAlgorithm<string \| Buffer>` — it needs a key it can put in a `SignPrivateKeyInput` |

Nothing casts back out. Verified that the compiler now rejects what it should:

```
TS2345: Argument of type 'CryptoKey' is not assignable to parameter of type
'Uint8Array<ArrayBufferLike> | KeyLike'.
```

The two arms the issue flagged as broken are now genuinely supported rather than narrowed away:

- **`Uint8Array`** is viewed as a `Buffer` (`Buffer.from(key.buffer, key.byteOffset, key.byteLength)`, no copy) instead of reaching OpenSSL as `ERR_OSSL_UNSUPPORTED`.
- **`ArrayBuffer`** data is viewed the same way, so `BinaryLike` is true for these algorithms. Test asserts an `ArrayBuffer` signs to the same bytes as the equivalent string.

## The residual hole, and why it fails closed

The signature algorithm is looked up by a URI read from the document under inspection, so a JavaScript caller can still pair a `CryptoKey` with a Node algorithm without the compiler seeing it. Confirmed on `master` that Node does not fail in that case — it signs:

```
master: signed with a CryptoKey, no error
(node:425927) [DEP0203] DeprecationWarning: Passing a CryptoKey to node:crypto functions is deprecated.
```

The signature verifies and the tests pass, so the algorithm appears to support a key it never really did, and it breaks whenever Node removes the shim. On this branch:

```
RsaSha256 needs a key that node:crypto accepts: a string, a Buffer, a Uint8Array, or a KeyObject
```

That check is the one piece of defensive code here; there is a comment saying why it exists despite the parameter type.

## Notes

- `CryptoKey` is spelled `crypto.webcrypto.CryptoKey` so it resolves under `lib: ["es2020"]` on the `@types/node@16` floor. A DOM or global `CryptoKey` is structurally identical and assignable.
- `getKeyInfoContent` still silently emits an empty `<X509Data/>` for key material it cannot read as PEM. That predates this change (a `KeyObject` does it today) and is left alone.

## Breaking

Source-compatible for callers. A break for anyone who **implements** `SignatureAlgorithm`: declare the key type, e.g. `implements SignatureAlgorithm<crypto.KeyLike>`. README `Upgrading` and a new "Declaring the key material your algorithm accepts" section cover it.

## Verification

`npm run build && npm test && npm run lint` clean; 244 passing (241 + 3). New tests in `test/key-material-tests.spec.ts` were confirmed to fail on `master` for the right reasons — two as compile errors, the `CryptoKey` one because `master` signs successfully.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader type support for signing keys, verification certificates, and signed data, including `Uint8Array` and `ArrayBuffer`.
  * Signature algorithms can now declare the key formats they support.

* **Bug Fixes**
  * Added clear errors for unsupported key material instead of relying on inconsistent runtime behavior.
  * Normalized binary inputs to produce consistent signatures.

* **Documentation**
  * Updated key format, signing, verification, and custom algorithm guidance for version 7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->