### PR TITLE
fix: collapse Algorithm URIs per xsd:anyURI

### DIFF
--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -630,7 +630,9 @@ export class SignedXml {
     }
 
     if (isDomNode.isAttributeNode(node)) {
-      this.canonicalizationAlgorithm = node.value as CanonicalizationAlgorithmType;
+      this.canonicalizationAlgorithm = utils.collapseAnyUri(
+        node.value,
+      ) as CanonicalizationAlgorithmType;
     }
 
     const signatureAlgorithm = xpath.select1(
@@ -639,7 +641,9 @@ export class SignedXml {
     );
 
     if (isDomNode.isAttributeNode(signatureAlgorithm)) {
-      this.signatureAlgorithm = signatureAlgorithm.value as SignatureAlgorithmType;
+      this.signatureAlgorithm = utils.collapseAnyUri(
+        signatureAlgorithm.value,
+      ) as SignatureAlgorithmType;
     }
 
     const signedInfoNodes = utils.findChildren(this.signatureNode, "SignedInfo");
@@ -718,7 +722,7 @@ export class SignedXml {
     if (!attr) {
       throw new Error(`could not find Algorithm attribute in node ${digestAlgoNode.toString()}`);
     }
-    const digestAlgo = attr.value;
+    const digestAlgo = utils.collapseAnyUri(attr.value);
 
     nodes = utils.findChildren(refNode, "DigestValue");
     if (nodes.length === 0) {
@@ -745,7 +749,7 @@ export class SignedXml {
         const transformAttr = utils.findAttr(transform, "Algorithm");
 
         if (transformAttr) {
-          transforms.push(transformAttr.value);
+          transforms.push(utils.collapseAnyUri(transformAttr.value));
         }
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,12 @@ export function findAttr(element: Element, localName: string, namespace?: string
   return null;
 }
 
+// `Algorithm` is xsd:anyURI. https://www.w3.org/TR/xmlschema-2/#anyURI
+// XML 1.0 §3.3.3 does not collapse, so this helper exists. https://www.w3.org/TR/xml/#AVNormalize
+export function collapseAnyUri(value: string): string {
+  return value.replace(/[\t\n\r ]+/g, " ").replace(/^ +| +$/g, "");
+}
+
 export function findChildren(node: Node | Document, localName: string, namespace?: string) {
   const element = (node as Document).documentElement ?? node;
   const res: Element[] = [];

--- a/test/algorithm-uri-whitespace.spec.ts
+++ b/test/algorithm-uri-whitespace.spec.ts
@@ -1,0 +1,144 @@
+import * as xpath from "xpath";
+import * as xmldom from "@xmldom/xmldom";
+import { SignedXml, findAncestorNs } from "../src/index";
+import * as fs from "fs";
+import { expect } from "chai";
+import * as isDomNode from "@xmldom/is-dom-node";
+
+const C14N = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+const ENVELOPED = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+const RSA_SHA1 = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+const SHA1 = "http://www.w3.org/2000/09/xmldsig#sha1";
+
+function signBook(): string {
+  const signer = new SignedXml({
+    privateKey: fs.readFileSync("./test/static/client.pem"),
+    canonicalizationAlgorithm: C14N,
+    signatureAlgorithm: RSA_SHA1,
+  });
+  signer.addReference({
+    xpath: "//*[local-name(.)='book']",
+    transforms: [ENVELOPED, C14N],
+    digestAlgorithm: SHA1,
+  });
+  signer.computeSignature("<library><book Id='b1'><title>Harry Potter</title></book></library>");
+  return signer.getSignedXml();
+}
+
+function wrapAlgorithm(xml: string, element: string, uri: string, wrapped: string): string {
+  const needle = `<${element} Algorithm="${uri}"/>`;
+  expect(xml.includes(needle), `signed xml should contain ${needle}`).to.equal(true);
+  return xml.replace(needle, `<${element} Algorithm="${wrapped}"/>`);
+}
+
+function load(xml: string): SignedXml {
+  const doc = new xmldom.DOMParser().parseFromString(xml, "text/xml");
+  const signatureNode = xpath.select1("//*[local-name(.)='Signature']", doc);
+  isDomNode.assertIsNodeLike(signatureNode);
+  const sig = new SignedXml({
+    publicCert: fs.readFileSync("./test/static/client_public.pem"),
+  });
+  sig.loadSignature(signatureNode);
+  return sig;
+}
+
+function resignOverWrappedSignedInfo(xml: string): string {
+  const doc = new xmldom.DOMParser().parseFromString(xml, "text/xml");
+  const signatureNode = xpath.select1("//*[local-name(.)='Signature']", doc);
+  isDomNode.assertIsNodeLike(signatureNode);
+  const sig = new SignedXml();
+  sig.loadSignature(signatureNode);
+  if (typeof sig.canonicalizationAlgorithm !== "string") {
+    throw new Error("canonicalizationAlgorithm missing after loadSignature");
+  }
+  if (sig.signatureAlgorithm == null) {
+    throw new Error("signatureAlgorithm missing after loadSignature");
+  }
+  const AlgoCtor = sig.SignatureAlgorithms[sig.signatureAlgorithm];
+  if (AlgoCtor == null) {
+    throw new Error(`signature algorithm '${sig.signatureAlgorithm}' is not supported`);
+  }
+  const signedInfo = xpath.select1(".//*[local-name(.)='SignedInfo']", signatureNode);
+  isDomNode.assertIsNodeLike(signedInfo);
+  const canon = sig.getCanonXml([sig.canonicalizationAlgorithm], signedInfo, {
+    ancestorNamespaces: findAncestorNs(doc, "//*[local-name(.)='SignedInfo']"),
+  });
+  const signatureValue = new AlgoCtor().getSignature(
+    canon,
+    fs.readFileSync("./test/static/client.pem"),
+  );
+  const resigned = xml.replace(
+    /(<SignatureValue>)([^<]*)(<\/SignatureValue>)/,
+    `$1${signatureValue}$3`,
+  );
+  if (resigned === xml) {
+    throw new Error("failed to replace SignatureValue");
+  }
+  return resigned;
+}
+
+function expectWrappedSignatureVerifies(element: string, uri: string, wrapped: string) {
+  const xml = resignOverWrappedSignedInfo(wrapAlgorithm(signBook(), element, uri, wrapped));
+  expect(xml.includes(`Algorithm="${wrapped}"`)).to.equal(true);
+  expect(load(xml).checkSignature(xml)).to.equal(true);
+}
+
+describe("xsd:anyURI whitespace collapse on Algorithm attributes", function () {
+  it("resolves CanonicalizationMethod when Algorithm is line-wrapped", function () {
+    const xml = wrapAlgorithm(signBook(), "CanonicalizationMethod", C14N, `${C14N}\n          `);
+    const sig = load(xml);
+
+    expect(sig.canonicalizationAlgorithm).to.equal(C14N);
+    expect(sig.signatureAlgorithm).to.equal(RSA_SHA1);
+    const ref = sig.getReferences()[0];
+    expect(ref.digestAlgorithm).to.equal(SHA1);
+    expect(ref.transforms).to.include(C14N);
+
+    expect(() => sig.checkSignature(xml)).to.throw(/invalid signature/);
+  });
+
+  it("verifies CanonicalizationMethod when leading whitespace was signed over", function () {
+    expectWrappedSignatureVerifies("CanonicalizationMethod", C14N, `\n          ${C14N}`);
+  });
+
+  [
+    { element: "CanonicalizationMethod", uri: C14N },
+    { element: "Transform", uri: C14N },
+    { element: "SignatureMethod", uri: RSA_SHA1 },
+    { element: "DigestMethod", uri: SHA1 },
+  ].forEach(({ element, uri }) => {
+    it(`verifies ${element} when line-wrapped Algorithm was signed over`, function () {
+      expectWrappedSignatureVerifies(element, uri, `${uri}\n          `);
+    });
+  });
+
+  it("misses the registry when Algorithm has an internal whitespace run", function () {
+    const xml = wrapAlgorithm(
+      signBook(),
+      "CanonicalizationMethod",
+      C14N,
+      "http://www.w3.org/TR/2001/\t\n          REC-xml-c14n-20010315",
+    );
+    expect(() => load(xml)).to.throw(
+      "canonicalization algorithm 'http://www.w3.org/TR/2001/ REC-xml-c14n-20010315' is not supported",
+    );
+  });
+
+  it("does not treat NBSP as Algorithm whitespace", function () {
+    const xml = wrapAlgorithm(signBook(), "CanonicalizationMethod", C14N, `\u00A0${C14N}`);
+    expect(() => load(xml)).to.throw(`canonicalization algorithm '\u00A0${C14N}' is not supported`);
+  });
+
+  it("still rejects a genuinely unregistered Algorithm URI after whitespace collapse", function () {
+    const xml = wrapAlgorithm(
+      signBook(),
+      "SignatureMethod",
+      RSA_SHA1,
+      "http://example.invalid/not-an-algorithm\n          ",
+    );
+    const sig = load(xml);
+    expect(() => sig.checkSignature(xml)).to.throw(
+      "signature algorithm 'http://example.invalid/not-an-algorithm' is not supported",
+    );
+  });
+});


### PR DESCRIPTION
**Maintainer review — 2026-09-11: hold this PR for a security regression.**

A reproduced case allows an attacker to insert an unsigned, whitespace-padded algorithm decoy into an already signed document and bypass a consumer's raw-string RSA-SHA1 prohibition. Master rejects the identifier; this PR normalizes it and returns `true` from `checkSignature`. This requires an existing valid RSA-SHA1 signature and the affected consumer check. The broad algorithm lookup predates this PR.

The [security review comment](https://github.com/node-saml/xml-crypto/pull/576#issuecomment-5639838236) records the tested revisions, results, prerequisites, controls, and why merely narrowing the library's selectors does not fully address the demonstrated consumer mismatch. For #548, preserve current rejection behavior and improve the diagnostic. Address signature structure and algorithm selection separately before reconsidering normalization. Earlier summaries that describe this change as having no merge-blocking security risk are superseded by that review.

---

Fixes #548

## Problem

`Algorithm` is looked up by exact string. XML 1.0 attribute-value normalization turns a line wrap into trailing spaces but does not collapse them, so a supported URI fails with `is not supported`. The exclusive-c14n guard in `loadSignature` compared that uncollapsed string too; the resulting unsupported-algorithm lookup failed closed.

## Fix

Collapse per `xsd:anyURI` (`whiteSpace="collapse"`) at the four `loadSignature` / `loadReference` read sites. Stored names then match the registries and the guard. The helper stays internal; the public barrel does not grow.

Changing an `Algorithm` attribute inside `SignedInfo` after signing still fails verification. The verify tests resign over the wrapped form, which is the pretty-print-then-sign path. However, the current descendant lookups can also select methods from unsigned content outside `SignedInfo`; normalization of those selected values enables the policy bypass described in the maintainer review above.

## Tests

- One verify case per affected element (`CanonicalizationMethod`, `Transform`, `SignatureMethod`, `DigestMethod`)
- Leading whitespace, internal whitespace runs, NBSP
- Unregistered URI still throws `is not supported`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML signature processing when algorithm identifiers contain leading, trailing, or repeated whitespace.
  * Signatures and references now resolve supported algorithm identifiers consistently when formatted with whitespace.
  * Unrecognized algorithm identifiers continue to be rejected after normalization.
  * Whitespace added after a signature was created still correctly causes verification to fail.

* **Tests**
  * Added coverage for whitespace handling across canonicalization, transformation, signature, and digest algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
