### PR TITLE
docs: note the inclusive canonicalization output change for upgraders

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@
 
 ## Upgrading
 
+### Inclusive canonicalization output
+
+Inclusive canonicalization (`http://www.w3.org/TR/2001/REC-xml-c14n-20010315` and its
+`#WithComments` variant) now renders namespace declarations as the
+[C14N specification](https://www.w3.org/TR/2001/REC-xml-c14n-20010315#ProcessingModel) requires.
+Earlier releases rendered some documents incorrectly, for example when:
+
+- a prefixed element in the signed content declares a default namespace, as in
+  `<p:item xmlns="urn:x">`
+- the signed element inherits a default namespace and declares a prefixed namespace of its own
+- the signed element is prefixed, inherits a default namespace, and contains an element that
+  clears it with `xmlns=""`
+- the signed element redeclares a prefix that an ancestor binds, after declaring another namespace
+
+For such documents this release computes a different digest than 6.1.x and earlier, so a
+signature created by one will not verify with the other. Upgrade signers and verifiers that
+exchange these documents together. Documents signed in these shapes by other conforming
+implementations, which 6.1.x rejected, now verify. Exclusive canonicalization is unaffected.
+
 ### Deprecated ahead of 7.0
 
 The package used to re-export everything in its internal `utils` module, so helpers written for


### PR DESCRIPTION
## Summary

#541 made inclusive canonicalization (`http://www.w3.org/TR/2001/REC-xml-c14n-20010315` and its `#WithComments` variant) render namespace declarations as the C14N specification requires. For the affected document shapes the digest differs from 6.1.x, so a signer and a verifier on different versions reject each other's signatures.

This adds a subsection to `## Upgrading` that lists those shapes, says to upgrade signers and verifiers that exchange such documents together, and notes that exclusive canonicalization is unaffected. The changelog is generated from PR titles, so the migration advice has to live in the README.

The listed shapes were checked against lxml's C14N output: this release matches it in each case and 6.1.2 does not.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated canonicalization guidance to identify version 6.2.0 as the release with changed digest behavior.
  * Documented an exception for exclusive canonicalization when using `InclusiveNamespaces`.
  * Retained compatibility and interoperability guidance for earlier versions.
  * Clarified deprecation wording by explicitly referencing version 6.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->