### PR TITLE
fix: publish signed references only after SignatureValue verifies

### DIFF
--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -523,7 +523,6 @@ export class SignedXml {
     throw new Error("No references passed validation");
   }
 
-  // The canonical XML returned is only trustworthy once SignatureValue has verified SignedInfo.
   private validateReference(ref: Reference, doc: Document): string | undefined {
     const uri = ref.uri?.[0] === "#" ? ref.uri.substring(1) : ref.uri;
     let elem: xpath.SelectSingleReturnType = null;

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -273,6 +273,11 @@ export class SignedXml {
       throw new Error("Last parameter must be a callback function");
     }
 
+    // Nothing this check has not authenticated may be visible, even if it throws partway. Success
+    // adds to what earlier successful checks on this instance published.
+    const earlierSignedReferences = this.signedReferences;
+    this.signedReferences = [];
+
     this.signedXml = xml;
 
     const doc = new xmldom.DOMParser().parseFromString(xml);
@@ -323,31 +328,23 @@ export class SignedXml {
       this.loadReference(reference);
     }
 
-    /* eslint-disable-next-line deprecation/deprecation */
-    if (!this.getReferences().every((ref) => this.validateReference(ref, doc))) {
-      /* Trustworthiness can only be determined if SignedInfo's (which holds References' DigestValue(s)
-         which were validated at this stage) signature is valid. Execution does not proceed to validate
-         signature phase thus each References' DigestValue must be considered to be untrusted (attacker
-         might have injected any data with new new references and/or recalculated new DigestValue for
-         altered Reference(s)). Returning any content via `signedReferences` would give false sense of
-         trustworthiness if/when SignedInfo's (which holds references' DigestValues) signature is not
-         valid(ated). Put simply: if one fails, they are all not trustworthy.
-      */
-      this.signedReferences = [];
-      this.references.forEach((ref) => {
-        ref.signedReference = undefined;
-      });
-      // TODO: add this breaking change here later on for even more security: `this.references = [];`
+    const canonReferences: string[] = [];
+    for (const ref of this.references) {
+      const canonXml = this.validateReference(ref, doc);
+      if (canonXml === undefined) {
+        // TODO: add this breaking change here later on for even more security: `this.references = [];`
 
-      if (callback) {
-        callback(new Error("Could not validate all references"), false);
-        return;
+        if (callback) {
+          callback(new Error("Could not validate all references"), false);
+          return;
+        }
+
+        // We return false because some references validated, but not all
+        // We should actually be throwing an error here, but that would be a breaking change
+        // See https://www.w3.org/TR/xmldsig-core/#sec-CoreValidation
+        return false;
       }
-
-      // We return false because some references validated, but not all
-      // We should actually be throwing an error here, but that would be a breaking change
-      // See https://www.w3.org/TR/xmldsig-core/#sec-CoreValidation
-      return false;
+      canonReferences.push(canonXml);
     }
 
     // (Stage B authentication step, show that the `signedInfoCanon` is signed)
@@ -363,19 +360,17 @@ export class SignedXml {
     // Check the signature verification to know whether to reset signature value or not.
     const sigRes = signer.verifySignature(unverifiedSignedInfoCanon, key, this.signatureValue);
     if (sigRes === true) {
+      this.signedReferences = [...earlierSignedReferences, ...canonReferences];
+      this.references.forEach((ref, index) => {
+        ref.signedReference = canonReferences[index];
+      });
+
       if (callback) {
         callback(null, true);
       } else {
         return true;
       }
     } else {
-      // Ideally, we would start by verifying the `signedInfoCanon` first,
-      // but that may cause some breaking changes, so we'll handle that in v7.x.
-      // If we were validating `signedInfoCanon` first, we wouldn't have to reset this array.
-      this.signedReferences = [];
-      this.references.forEach((ref) => {
-        ref.signedReference = undefined;
-      });
       // TODO: add this breaking change here later on for even more security: `this.references = [];`
 
       if (callback) {
@@ -528,7 +523,8 @@ export class SignedXml {
     throw new Error("No references passed validation");
   }
 
-  private validateReference(ref: Reference, doc: Document) {
+  // The canonical XML returned is only trustworthy once SignatureValue has verified SignedInfo.
+  private validateReference(ref: Reference, doc: Document): string | undefined {
     const uri = ref.uri?.[0] === "#" ? ref.uri.substring(1) : ref.uri;
     let elem: xpath.SelectSingleReturnType = null;
 
@@ -573,7 +569,7 @@ export class SignedXml {
         `invalid signature: the signature references an element with uri ${ref.uri} but could not find such element in the xml`,
       );
       ref.validationError = validationError;
-      return false;
+      return undefined;
     }
 
     const canonXml = this.getCanonReferenceXml(doc, ref, elem);
@@ -586,16 +582,10 @@ export class SignedXml {
       );
       ref.validationError = validationError;
 
-      return false;
+      return undefined;
     }
-    // This step can only be done after we have verified the `signedInfo`.
-    // We verified that they have same hash,
-    // thus the `canonXml` and _only_ the `canonXml` can be trusted.
-    // Append this to `signedReferences`.
-    this.signedReferences.push(canonXml);
-    ref.signedReference = canonXml;
 
-    return true;
+    return canonXml;
   }
 
   findSignatures(doc: Node): Node[] {

--- a/test/signed-references-tests.spec.ts
+++ b/test/signed-references-tests.spec.ts
@@ -1,0 +1,111 @@
+import * as xpath from "xpath";
+import * as xmldom from "@xmldom/xmldom";
+import { SignedXml, type SignedXmlOptions } from "../src/index";
+import * as fs from "fs";
+import { expect } from "chai";
+import * as isDomNode from "@xmldom/is-dom-node";
+
+describe("Signed references", function () {
+  const exclusiveC14n = "http://www.w3.org/2001/10/xml-exc-c14n#";
+  const rsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+  const hmacSha1 = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+  const publicCert = fs.readFileSync("./test/static/client_public.pem");
+
+  // Two references, so a check that fails on the second shows whether the first leaked.
+  function sign(): string {
+    const sig = new SignedXml({
+      privateKey: fs.readFileSync("./test/static/client.pem"),
+      canonicalizationAlgorithm: exclusiveC14n,
+      signatureAlgorithm: rsaSha256,
+    });
+    for (const name of ["assertion", "extensions"]) {
+      sig.addReference({
+        xpath: `//*[local-name(.)='${name}']`,
+        transforms: [exclusiveC14n],
+        digestAlgorithm: "http://www.w3.org/2001/04/xmlenc#sha256",
+      });
+    }
+    sig.computeSignature("<response><assertion>signed</assertion><extensions/></response>");
+    return sig.getSignedXml();
+  }
+
+  function loadSignature(sig: SignedXml, xml: string): SignedXml {
+    const signature = xpath.select1(
+      "//*[local-name(.)='Signature']",
+      new xmldom.DOMParser().parseFromString(xml),
+    );
+    isDomNode.assertIsNodeLike(signature);
+    sig.loadSignature(signature);
+    return sig;
+  }
+
+  const cases: Array<[string, (xml: string) => string, SignedXmlOptions, string | RegExp]> = [
+    [
+      "the SignatureMethod is not enabled",
+      (xml) => xml.replace(rsaSha256, hmacSha1),
+      { publicCert },
+      `signature algorithm '${hmacSha1}' is not supported`,
+    ],
+    [
+      "there is no SignatureMethod",
+      (xml) => xml.replace(/<SignatureMethod [^>]*\/>/, ""),
+      { publicCert },
+      "signatureAlgorithm is required",
+    ],
+    [
+      "the second Reference names an unsupported DigestMethod",
+      (xml) =>
+        xml.replace(
+          /(<Reference URI="#_1">.*?<DigestMethod Algorithm=")[^"]*/,
+          "$1urn:example:unknown",
+        ),
+      { publicCert },
+      "hash algorithm 'urn:example:unknown' is not supported",
+    ],
+    [
+      "the id the second Reference points at is not unique",
+      (xml) => xml.replace("</response>", '<extensions ID="_1"/></response>'),
+      { publicCert },
+      /in order to prevent signature wrapping attack/,
+    ],
+    ["no key is configured", (xml) => xml, {}, /^KeyInfo or publicCert or privateKey is required/],
+    [
+      "getCertFromKeyInfo cannot parse the embedded certificate",
+      (xml) =>
+        xml.replace(
+          "</Signature>",
+          "<KeyInfo><X509Data><X509Certificate>%%%</X509Certificate></X509Data></KeyInfo></Signature>",
+        ),
+      { getCertFromKeyInfo: SignedXml.getCertFromKeyInfo },
+      "Unknown DER format.",
+    ],
+  ];
+
+  for (const [problem, malform, options, error] of cases) {
+    it(`are empty after checkSignature throws because ${problem}`, function () {
+      const xml = malform(sign());
+      const sig = loadSignature(new SignedXml(options), xml);
+
+      expect(() => sig.checkSignature(xml)).to.throw(error);
+      expect(sig.getSignedReferences()).to.be.empty;
+      /* eslint-disable-next-line deprecation/deprecation */
+      expect(sig.getReferences().map((ref) => ref.signedReference)).to.deep.equal([
+        undefined,
+        undefined,
+      ]);
+    });
+  }
+
+  it("from an earlier check do not survive a later check that throws", function () {
+    const xml = sign();
+    const sig = loadSignature(new SignedXml({ publicCert }), xml);
+    expect(sig.checkSignature(xml)).to.be.true;
+    expect(sig.getSignedReferences()).to.have.lengthOf(2);
+
+    const unsupported = xml.replace(rsaSha256, hmacSha1);
+    loadSignature(sig, unsupported);
+
+    expect(() => sig.checkSignature(unsupported)).to.throw(/is not supported/);
+    expect(sig.getSignedReferences()).to.be.empty;
+  });
+});


### PR DESCRIPTION
## Summary

`checkSignature` pushed each reference's canonical XML into `signedReferences` and `ref.signedReference` as soon as its digest matched, before it resolved the signature algorithm and key and before it checked `SignatureValue`. Only the paths that return `false` cleared them. Any exception after the first digest left content nobody signed readable through `getSignedReferences()`, for example:

- an unregistered, disabled or missing SignatureMethod
- an unsupported DigestMethod or a duplicated ID on a later Reference
- no key, or a `getCertFromKeyInfo` that throws

Digests are not keyed, so that content is attacker-chosen.

`validateReference` now returns the canonical XML instead of publishing it, and `checkSignature` publishes it only once `SignatureValue` verifies. A check that throws now leaves `signedReferences` empty, as `return false` already did, including on an instance where an earlier check succeeded.

## Compatibility

The checks run in the same order, so every document gets the return value or error it got before, and success, `return false` and `invalid signature` leave the same state behind. As before, a successful check adds to what earlier successful checks on the same instance published. Only what a check that throws leaves behind changes. 6.1.2's test suite passes unchanged against this branch, and the new tests fail on master for the reason above.

Fixes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML signature validation so signed references are published only after the signature is successfully authenticated.
  * Invalid or failed signature checks no longer expose partially validated reference content.
  * Signed references are cleared when a subsequent validation attempt fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
