### PR TITLE
fix: canonicalize a node-set left at the end of the transforms

### DIFF
--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -1304,13 +1304,6 @@ export class SignedXml {
         const transform = this.findCanonicalizationAlgorithm(transformName);
         transformedXml = transform.process(transformedXml, options);
       }
-      //TODO: currently transform.process may return either Node or String value (enveloped transformation returns Node, exclusive-canonicalization returns String).
-      //This either needs to be more explicit in the API, or all should return the same.
-      //exclusive-canonicalization returns String since it builds the Xml by hand. If it had used xmldom it would incorrectly minimize empty tags
-      //to <x/> instead of <x></x> and also incorrectly handle some delicate line break issues.
-      //enveloped transformation returns Node since if it would return String consider this case:
-      //<x xmlns:p='ns'><p:y/></x>
-      //if only y is the node to sign then a string would be <p:y/> without the definition of the p namespace. probably xmldom toString() should have added it.
     });
 
     // A node-set is converted to octets with C14N, never with a DOM serializer:

--- a/src/signed-xml.ts
+++ b/src/signed-xml.ts
@@ -1313,6 +1313,14 @@ export class SignedXml {
       //if only y is the node to sign then a string would be <p:y/> without the definition of the p namespace. probably xmldom toString() should have added it.
     });
 
+    // A node-set is converted to octets with C14N, never with a DOM serializer:
+    // https://www.w3.org/TR/xmldsig-core1/#sec-ReferenceProcessingModel
+    if (isDomNode.isNodeLike(transformedXml)) {
+      transformedXml = this.findCanonicalizationAlgorithm(
+        "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+      ).process(transformedXml, options);
+    }
+
     return transformedXml.toString();
   }
 

--- a/test/c14nWithComments-unit-tests.spec.ts
+++ b/test/c14nWithComments-unit-tests.spec.ts
@@ -376,7 +376,7 @@ describe("Exclusive canonicalization with comments", function () {
     const transforms = ["http://www.w3.org/2000/09/xmldsig#enveloped-signature"];
     isDomNode.assertIsNodeLike(node);
     const res = sig.getCanonXml(transforms, node);
-    expect(res).to.equal("<y/>");
+    expect(res).to.equal("<y></y>");
   });
 
   it("The XML canonicalization method processes a node-set by imposing the following additional document order rules on the namespace and attribute nodes of each element: \

--- a/test/canonicalization-unit-tests.spec.ts
+++ b/test/canonicalization-unit-tests.spec.ts
@@ -500,7 +500,7 @@ describe("Canonicalization unit tests", function () {
     const sig = new SignedXml();
     const transforms = ["http://www.w3.org/2000/09/xmldsig#enveloped-signature"];
     const res = sig.getCanonXml(transforms, node);
-    expect(res).to.equal("<y/>");
+    expect(res).to.equal("<y></y>");
   });
 
   it("Enveloped-signature canonicalization preserves nested signatures when removing a direct child", function () {

--- a/test/signature-integration-tests.spec.ts
+++ b/test/signature-integration-tests.spec.ts
@@ -257,6 +257,34 @@ describe("Signature integration tests", function () {
     expect(verifier.checkSignature(signedXml)).to.be.true;
   });
 
+  it("should create valid signature when enveloped-signature is the only transform", function () {
+    const xml = "<root><x Id='ref1' b='2' a='1'/></root>";
+
+    const sig = new SignedXml({
+      privateKey: fs.readFileSync("./test/static/client.pem"),
+      canonicalizationAlgorithm: "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+      signatureAlgorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+    });
+    sig.addReference({
+      xpath: "//*[local-name(.)='x']",
+      transforms: ["http://www.w3.org/2000/09/xmldsig#enveloped-signature"],
+      digestAlgorithm: "http://www.w3.org/2001/04/xmlenc#sha256",
+    });
+    sig.computeSignature(xml);
+    const signedXml = sig.getSignedXml();
+
+    const doc = new xmldom.DOMParser().parseFromString(signedXml);
+    const signatureNode = xpath.select1("//*[local-name(.)='Signature']", doc);
+    isDomNode.assertIsNodeLike(signatureNode);
+
+    const verifier = new SignedXml();
+    verifier.publicCert = fs.readFileSync("./test/static/client_public.pem");
+    verifier.loadSignature(signatureNode);
+
+    expect(verifier.checkSignature(signedXml)).to.be.true;
+    expect(verifier.getSignedReferences()).to.deep.equal(['<x Id="ref1" a="1" b="2"></x>']);
+  });
+
   it("should still verify a loaded signature after signing another document fails", function () {
     const signedXml = fs.readFileSync("./test/static/valid_signature.xml", "utf8");
     const doc = new xmldom.DOMParser().parseFromString(signedXml);


### PR DESCRIPTION
## Summary

When a reference's transforms ended in `enveloped-signature`, signing digested xmldom's `node.toString()` while verification appended inclusive C14N in `loadReference`. Any document whose serialization is not already canonical, such as one with a self-closing tag or attributes out of order, got a signature no version of this library could verify.

Both sides reach the digest through `getCanonXml`, so it now converts a node-set left after the last transform to octets with inclusive C14N, as the [reference processing model](https://www.w3.org/TR/xmldsig-core1/#sec-ReferenceProcessingModel) requires. Signing and verification canonicalize under the same condition by construction, and verification of existing signatures using the built-in algorithms is unchanged. This also drops the `getCanonXml` TODO about transforms returning either a Node or a string. Transforms after one that returns a string are still skipped rather than getting the octet-to-node-set conversion; that is tracked in #111.

## Compatibility

Documented in the README's Upgrading section.

- Signatures created for such references now verify with 6.1.2 as well.
- `getCanonXml()` is public. For a transform list ending in a node-set it now returns canonical XML (`<y></y>`) instead of xmldom's serialization (`<y/>`). Two tests pinned the old output and are updated.
- `CanonicalizationOrTransformationAlgorithm.process()` is typed `Node | string`. A custom transform, or a custom `SignedInfo` canonicalization algorithm, that returns a Node is now canonicalized on both sides, so its digest or signature differs from 6.1.x: signatures created with it by 6.1.x no longer verify, and the reverse. Signers and verifiers using one need to upgrade together.

Fixes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XML signature canonicalization when transformations return DOM nodes, producing consistent canonical output.
  - Updated empty-element handling to use explicit start and end tags where required.
  - Improved verification reliability for enveloped-signature transformations, including preservation of inherited namespaces.

- **Documentation**
  - Added guidance on DOM-node transformations, canonicalization behavior, verification, and compatibility differences affecting custom transformations and canonicalizers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->